### PR TITLE
feat(models): use UUIDv7 for `AuditLog.id`

### DIFF
--- a/invenio_audit_logs/records/models.py
+++ b/invenio_audit_logs/records/models.py
@@ -7,10 +7,15 @@
 
 """Base model classes for Audit Logs in Invenio."""
 
-
 from invenio_db import db
 from invenio_records.models import RecordMetadataBase
 from sqlalchemy.types import String
+from sqlalchemy_utils.types import UUIDType
+
+try:
+    from uuid import uuid7
+except ImportError:
+    from uuid_utils.compat import uuid7
 
 
 class AuditLog(db.Model, RecordMetadataBase):
@@ -19,6 +24,12 @@ class AuditLog(db.Model, RecordMetadataBase):
     __tablename__ = "audit_logs_metadata"
 
     encoder = None
+
+    id = db.Column(
+        UUIDType,
+        primary_key=True,
+        default=uuid7,
+    )
 
     action = db.Column(String(255), nullable=False)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     invenio-records-resources>=8.0.0,<9.0.0
     invenio-administration>=4.0.0,<5.0.0
     invenio-accounts>=6.0.0,<7.0.0
+    uuid-utils>=0.11.1; python_version < '3.14'
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
This is in anticipation of testing the module for using [PostgreSQL table partitioning](https://www.postgresql.org/docs/current/ddl-partitioning.html).

With a UUIDv7 column, we could partition the table solely on the `id` column, without having to have a composite primary key to also use the existing `created` column ([see also the `pg_partman` How-to guide](https://github.com/pgpartman/pg_partman/blob/development/doc/pg_partman_howto.md#simple-time-based-with-uuidv7-type-1-partition-per-day)).