### PR TITLE
feat: Configuration of service components

### DIFF
--- a/invenio_audit_logs/services/config.py
+++ b/invenio_audit_logs/services/config.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 CERN.
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
 # SPDX-License-Identifier: MIT
 
 """Audit Logs Service Config."""
@@ -97,7 +98,10 @@ class AuditLogServiceConfig(ServiceConfig, ConfiguratorMixin):
     indexer_queue_name = service_id
     index_dumper = None
 
-    components = []
+    components = FromConfig(
+        "AUDIT_LOGS_SERVICE_COMPONENTS",
+        default=[],
+    )
     links_item = {
         "self": EndpointLink(
             "audit_logs.read",

--- a/invenio_audit_logs/services/service.py
+++ b/invenio_audit_logs/services/service.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 CERN.
 # SPDX-FileCopyrightText: 2025 Graz University of Technology.
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
 # SPDX-License-Identifier: MIT
 
 """Audit Logs Service API."""
@@ -67,6 +68,15 @@ class AuditLogService(RecordService):
             **data,
         )
 
+        self.run_components(
+            "create",
+            identity,
+            data=data,
+            record=record,
+            errors=errors,
+            uow=uow,
+        )
+
         # Persist record (DB and index)
         uow.register(AuditRecordCommitOp(record, self.indexer))
 
@@ -89,6 +99,12 @@ class AuditLogService(RecordService):
 
         # Read the record
         log = self.record_cls.get_record(id_=id_)
+
+        self.run_components(
+            "read",
+            identity,
+            record=log,
+        )
 
         # Return the result
         return self.result_item(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 CERN.
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
 # SPDX-License-Identifier: MIT
 
 """Pytest configuration.
@@ -9,6 +10,7 @@ fixtures are available.
 
 import pytest
 from invenio_app.factory import create_api as _create_api
+from mock_module.auditlog.components import CallTrackingComponent
 
 
 @pytest.fixture(scope="module")
@@ -16,6 +18,8 @@ def app_config(app_config):
     """Application config override."""
     app_config["THEME_FRONTPAGE"] = False
     app_config["AUDIT_LOGS_ENABLED"] = True
+
+    app_config["AUDIT_LOGS_SERVICE_COMPONENTS"] = [CallTrackingComponent]
     return app_config
 
 

--- a/tests/mock_module/auditlog/components.py
+++ b/tests/mock_module/auditlog/components.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+"""Test components."""
+
+from invenio_records_resources.services.records.components import ServiceComponent
+
+
+class CallTrackingComponent(ServiceComponent):
+    """Test component.
+
+    It does not modify the record, just tracks if it was called.
+    """
+
+    create_called = False
+    read_called = False
+
+    def create(self, identity, data, record=None, **kwargs):
+        """Create action."""
+        CallTrackingComponent.create_called = True
+
+    def read(self, identity, record=None, **kwargs):
+        """Read action."""
+        CallTrackingComponent.read_called = True
+
+    @classmethod
+    def reset(cls):
+        """Reset the component state."""
+        CallTrackingComponent.create_called = False
+        CallTrackingComponent.read_called = False

--- a/tests/services/test_service.py
+++ b/tests/services/test_service.py
@@ -1,12 +1,13 @@
 # SPDX-FileCopyrightText: 2025 CERN.
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
 # SPDX-License-Identifier: MIT
 """Test audit log service."""
 
 import pytest
-from flask import g
 from flask_login import login_user
 from invenio_access.permissions import system_identity
 from invenio_records_resources.services.errors import PermissionDeniedError
+from mock_module.auditlog.components import CallTrackingComponent
 
 
 def test_audit_log_create(
@@ -19,16 +20,20 @@ def test_audit_log_create(
     """Should succeed when identity matches g.identity."""
     login_user(current_user, force=True)
 
+    CallTrackingComponent.reset()
     with app.test_request_context():
         result = service.create(
             identity=system_identity,
             data=resource_data,
         )
+    assert CallTrackingComponent.create_called
 
+    CallTrackingComponent.reset()
     result = service.read(
         identity=system_identity,
         id_=result.id,
     )
+    assert CallTrackingComponent.read_called
 
     assert result["action"] == "draft.create"
     assert result["resource"] == {
@@ -55,7 +60,7 @@ def test_audit_log_create(
     expected_links = {
         "self": (
             "https://127.0.0.1:5000/api/audit-logs/?"
-            f"page=1&q=resource.id:+abcd-1234+AND+action:+draft.create"
+            "page=1&q=resource.id:+abcd-1234+AND+action:+draft.create"
             "&size=20&sort=newest"
         )
     }


### PR DESCRIPTION
### Description

This pull request adds configuration option `AUDIT_LOGS_SERVICE_COMPONENTS` to be able to register service components for audit log service in an Invenio instance. If not set, no components are registered (which is the state before the PR).

An example when these components might be used is to send the audit log event to an external system (such as a graylog instance) as soon as possible.

The PR fixes [issue #16](https://github.com/inveniosoftware/invenio-audit-logs/issues/16).

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
