### PR TITLE
Audit log actions allowlist config

### DIFF
--- a/invenio_audit_logs/config.py
+++ b/invenio_audit_logs/config.py
@@ -45,9 +45,23 @@ AUDIT_LOGS_SORT_OPTIONS = {
 AUDIT_LOGS_ENABLED = False
 """Feature flag. Disabled by default."""
 
+AUDIT_LOGS_ENABLED_ACTIONS = None
+"""
+Allow-list of actions to include in the audit logs.
+
+``None`` (the default) allows all registered actions. Set it to a set of action
+names to log only those; any other action is skipped. An action in
+``AUDIT_LOGS_DISABLED_ACTIONS`` is never logged, even if you list it here.
+To find all the available actions, check the entry points in the `invenio_audit_logs.actions` group.
+```python
+>>> from invenio_base.utils import entry_points
+>>> [ep.name for ep in entry_points(group="invenio_audit_logs.actions")]
+```
+"""
+
 AUDIT_LOGS_DISABLED_ACTIONS = set()
 """
-Disabled actions to be excluded from the audit logs.
+Deny-list of actions to be excluded from the audit logs.
 To find all the available actions, check the entry points in the `invenio_audit_logs.actions` group.
 ```python
 >>> from invenio_base.utils import entry_points

--- a/invenio_audit_logs/ext.py
+++ b/invenio_audit_logs/ext.py
@@ -24,6 +24,7 @@ class InvenioAuditLogs(object):
         self.init_services(app)
         self.init_resources(app)
         self.load_actions_registry()
+        self.validate_actions_config(app)
         app.extensions["invenio-audit-logs"] = self
 
     def init_config(self, app):
@@ -54,3 +55,24 @@ class InvenioAuditLogs(object):
             action_name = action.id
             self.actions_registry[action_name] = action
             self.schema_cache[action_name] = action.marshmallow_schema()
+
+    def validate_actions_config(self, app):
+        """Check the action allow/deny lists against the registry."""
+        known = set(self.actions_registry)
+        enabled = set(app.config.get("AUDIT_LOGS_ENABLED_ACTIONS") or set())
+        disabled = set(app.config.get("AUDIT_LOGS_DISABLED_ACTIONS") or set())
+
+        unknown = (enabled | disabled) - known
+        if unknown:
+            raise RuntimeError(
+                f"Unknown audit log actions configured: {sorted(unknown)}. "
+                f"Registered actions are: {sorted(known)}."
+            )
+
+        overlap = enabled & disabled
+        if overlap:
+            raise RuntimeError(
+                f"Audit log actions {sorted(overlap)} are in both "
+                "AUDIT_LOGS_ENABLED_ACTIONS and AUDIT_LOGS_DISABLED_ACTIONS. "
+                "An action cannot be both allowed and denied."
+            )

--- a/invenio_audit_logs/services/config.py
+++ b/invenio_audit_logs/services/config.py
@@ -82,6 +82,7 @@ class AuditLogServiceConfig(ServiceConfig, ConfiguratorMixin):
     """Audit log service configuration."""
 
     enabled = FromConfig("AUDIT_LOGS_ENABLED", default=True)
+    enabled_actions = FromConfig("AUDIT_LOGS_ENABLED_ACTIONS", default=None)
     disabled_actions = FromConfig("AUDIT_LOGS_DISABLED_ACTIONS", default=set())
 
     service_id = "audit-logs"

--- a/invenio_audit_logs/services/service.py
+++ b/invenio_audit_logs/services/service.py
@@ -43,8 +43,12 @@ class AuditLogService(RecordService):
             return
 
         action = data["action"]
+        enabled_actions = self.config.enabled_actions
+        # If an allow-list is set, only log actions that are on it.
+        if enabled_actions is not None and action not in enabled_actions:
+            return
+        # A disabled action is never logged, even if the allow-list includes it.
         if action in self.config.disabled_actions:
-            # use config flag to opt out of certain audit actions as required
             return
 
         self.require_permission(identity, "create")

--- a/invenio_audit_logs/services/service.py
+++ b/invenio_audit_logs/services/service.py
@@ -47,7 +47,7 @@ class AuditLogService(RecordService):
         # If an allow-list is set, only log actions that are on it.
         if enabled_actions is not None and action not in enabled_actions:
             return
-        # A disabled action is never logged, even if the allow-list includes it.
+        # Skip actions on the deny-list.
         if action in self.config.disabled_actions:
             return
 

--- a/tests/services/test_ext.py
+++ b/tests/services/test_ext.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Test extension config validation."""
+
+import pytest
+
+
+def test_validate_actions_config_rejects_unknown(app, monkeypatch):
+    """Unknown action names in the config fail validation."""
+    ext = app.extensions["invenio-audit-logs"]
+    monkeypatch.setitem(
+        app.config, "AUDIT_LOGS_ENABLED_ACTIONS", {"draft.create", "does.not.exist"}
+    )
+    with pytest.raises(RuntimeError, match="Unknown audit log actions"):
+        ext.validate_actions_config(app)
+
+
+def test_validate_actions_config_rejects_overlap(app, monkeypatch):
+    """An action in both the allow- and deny-list fails validation."""
+    ext = app.extensions["invenio-audit-logs"]
+    monkeypatch.setitem(app.config, "AUDIT_LOGS_ENABLED_ACTIONS", {"draft.create"})
+    monkeypatch.setitem(app.config, "AUDIT_LOGS_DISABLED_ACTIONS", {"draft.create"})
+    with pytest.raises(RuntimeError, match="both"):
+        ext.validate_actions_config(app)

--- a/tests/services/test_service.py
+++ b/tests/services/test_service.py
@@ -128,3 +128,33 @@ def test_audit_log_config_disabled(
             data=resource_data,
         )
     assert result is None
+
+
+def test_audit_log_enabled_actions_allow_list(
+    app, service, resource_data, system_user, monkeypatch
+):
+    """Allow-list opts in to specific actions only."""
+    resource_data["user"] = system_user
+
+    # Action not in the allow-list is skipped.
+    monkeypatch.setitem(
+        app.config, "AUDIT_LOGS_ENABLED_ACTIONS", set(["community.create"])
+    )
+    with app.test_request_context():
+        result = service.create(identity=system_identity, data=resource_data)
+    assert result is None
+
+    # Action in the allow-list is logged.
+    monkeypatch.setitem(app.config, "AUDIT_LOGS_ENABLED_ACTIONS", set(["draft.create"]))
+    with app.test_request_context():
+        result = service.create(identity=system_identity, data=resource_data)
+    assert result is not None
+    assert result["action"] == "draft.create"
+
+    # Deny-list wins over allow-list.
+    monkeypatch.setitem(
+        app.config, "AUDIT_LOGS_DISABLED_ACTIONS", set(["draft.create"])
+    )
+    with app.test_request_context():
+        result = service.create(identity=system_identity, data=resource_data)
+    assert result is None


### PR DESCRIPTION
- **feat(config): add allow-list to opt in to specific audit actions**
  * AUDIT_LOGS_ENABLED_ACTIONS defaults to None, meaning all registered actions are logged
  * Set it to a set of action names to log only those
  * A deny-list alone meant newly added actions would start logging unless every instance updated its config; the allow-list lets instances opt in explicitly
  * AUDIT_LOGS_DISABLED_ACTIONS still takes precedence, so a denied action is never logged
  

- **feat(ext): validate audit action allow/deny lists at startup**
  * Raise if either list names an action that isn't registered (a typo would otherwise silently skip nothing)
  * Raise if the same action is in both the allow-list and the deny-list
  