### PR TITLE
Audit logs retention

### DIFF
--- a/invenio_audit_logs/__init__.py
+++ b/invenio_audit_logs/__init__.py
@@ -5,10 +5,12 @@
 """Module providing audit logging features for Invenio.."""
 
 from .ext import InvenioAuditLogs
+from .retention import KEEP_FOREVER
 
 __version__ = "4.0.0"
 
 __all__ = (
     "__version__",
     "InvenioAuditLogs",
+    "KEEP_FOREVER",
 )

--- a/invenio_audit_logs/alembic/1743073617_create_audit_logs_branch.py
+++ b/invenio_audit_logs/alembic/1743073617_create_audit_logs_branch.py
@@ -3,9 +3,6 @@
 
 """Create Audit logs branch."""
 
-import sqlalchemy as sa
-from alembic import op
-
 # revision identifiers, used by Alembic.
 revision = "1743073617"
 down_revision = None

--- a/invenio_audit_logs/alembic/c9a2f1d4e6b8_create_retention_runs_table.py
+++ b/invenio_audit_logs/alembic/c9a2f1d4e6b8_create_retention_runs_table.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Create audit log retention runs table."""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = "c9a2f1d4e6b8"
+down_revision = "42fa8d3bbc0c"
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.create_table(
+        "audit_logs_retention_runs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "run_at",
+            sa.DateTime().with_variant(mysql.DATETIME(fsp=6), "mysql"),
+            nullable=False,
+        ),
+        sa.Column("action", sa.String(length=255), nullable=False),
+        sa.Column("retention_days", sa.Integer(), nullable=False),
+        sa.Column("month", sa.Date(), nullable=False),
+        sa.Column("rows_deleted", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_audit_logs_retention_runs")),
+    )
+
+
+def downgrade():
+    """Downgrade database."""
+    op.drop_table("audit_logs_retention_runs")

--- a/invenio_audit_logs/alembic/f0e1d2c3b4a5_rewrite_ids_to_uuid7.py
+++ b/invenio_audit_logs/alembic/f0e1d2c3b4a5_rewrite_ids_to_uuid7.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Change existing audit log ids to UUIDv7, based on each row's ``created`` time."""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f0e1d2c3b4a5"
+down_revision = "c9a2f1d4e6b8"
+branch_labels = ()
+depends_on = None
+
+# Build a new id for every row in one UPDATE. A UUIDv7 starts with a 48-bit
+# millisecond timestamp, then the digit 7, then random bits. We take the timestamp
+# from each row's ``created`` (stored as UTC), so the new ids sort in time order.
+# ``gen_random_uuid()`` gives the random bits and comes built into PostgreSQL.
+REWRITE_IDS_TO_UUID7 = """
+UPDATE audit_logs_metadata
+SET id = (
+    lpad(to_hex((extract(epoch FROM created) * 1000)::bigint), 12, '0')
+    || '7'
+    || substr(replace(gen_random_uuid()::text, '-', ''), 1, 3)
+    || to_hex(8 + floor(random() * 4)::int)
+    || substr(replace(gen_random_uuid()::text, '-', ''), 1, 15)
+)::uuid
+"""
+
+
+def upgrade():
+    """Give every existing row a UUIDv7 id based on its ``created`` time.
+
+    This is what lets an operator partition the table by time on the primary key.
+    Changing the id is safe: audit log ids are never foreign keys, and retention
+    deletes rows by ``created``, not by id, so nothing else changes. After this,
+    rebuild the search copy from PostgreSQL with ``AuditLogService.reindex`` so
+    OpenSearch uses the new ids.
+    """
+    op.execute(REWRITE_IDS_TO_UUID7)
+
+
+def downgrade():
+    """Do nothing: the change cannot be undone, and nothing points at these ids.
+
+    The old ids are gone after the rewrite, and no other table references an audit
+    log id, so there is nothing to put back.
+    """

--- a/invenio_audit_logs/config.py
+++ b/invenio_audit_logs/config.py
@@ -3,9 +3,9 @@
 
 """Configuration for invenio-audit-logs."""
 
-from invenio_records_resources.services.records.facets import TermsFacet
+from datetime import timedelta
 
-from .proxies import current_audit_logs_actions_registry
+from invenio_records_resources.services.records.facets import TermsFacet
 
 AUDIT_LOGS_SEARCH = {
     "facets": ["resource", "action_name"],
@@ -54,3 +54,30 @@ To find all the available actions, check the entry points in the `invenio_audit_
 >>> [ep.name for ep in entry_points(group="invenio_audit_logs.actions")]
 ```
 """
+
+AUDIT_LOGS_RETENTION_DEFAULT = timedelta(days=395)
+"""Retention applied to any action without an explicit entry below.
+
+Finite on purpose: a new or unconfigured action is kept for this period rather
+than forever by oversight. ~13 months is a common security-log default. Periods
+are interpreted at whole-month granularity, so events can be up to one month
+older than the nominal period before the next monthly run clears them.
+"""
+
+AUDIT_LOGS_RETENTION = {}
+"""Per-action retention periods, keyed on the action id.
+
+Each value is a ``timedelta`` or the ``KEEP_FOREVER`` sentinel. Keeping an action
+forever is the deliberate exception, e.g.::
+
+    from datetime import timedelta
+    from invenio_audit_logs import KEEP_FOREVER
+
+    AUDIT_LOGS_RETENTION = {
+        "user.login": timedelta(days=60),
+        "user.block": KEEP_FOREVER,
+    }
+"""
+
+AUDIT_LOGS_RETENTION_BATCH_SIZE = 1000
+"""Rows deleted per transaction when deleting expired events from PostgreSQL."""

--- a/invenio_audit_logs/records/api.py
+++ b/invenio_audit_logs/records/api.py
@@ -28,8 +28,13 @@ class AuditLog(Record):
     )
     """Search dumper with configured dump keys."""
 
-    index = IndexField("auditlog-audit-log-v2.0.0", search_alias="auditlog")
-    """The search engine index to use."""
+    index = IndexField("auditlog", search_alias="auditlog")
+    """Read alias spanning the monthly ``auditlog-YYYY-MM`` indices.
+
+    Writes route to a per-month index derived from ``created`` (see
+    ``AuditLogService.record_to_index``); this alias is what search and refresh
+    use to reach every month at once.
+    """
 
     id = ModelField("id", dump_type=UUID)
 

--- a/invenio_audit_logs/records/mappings/templates/os-v1/auditlogs/datastream-auditlog-v1.0.0.json
+++ b/invenio_audit_logs/records/mappings/templates/os-v1/auditlogs/datastream-auditlog-v1.0.0.json
@@ -1,6 +1,5 @@
 {
   "index_patterns": ["__SEARCH_INDEX_PREFIX__auditlog*"],
-  "data_stream": {},
   "template": {
     "settings": {
       "analysis": {
@@ -31,6 +30,7 @@
       "dynamic": "strict",
       "numeric_detection": false,
       "properties": {
+        "@timestamp": { "type": "date" },
         "id": { "type": "keyword" },
         "uuid": { "type": "keyword" },
         "version_id": { "type": "integer" },

--- a/invenio_audit_logs/records/mappings/templates/os-v1/auditlogs/datastream-auditlog-v2.0.0.json
+++ b/invenio_audit_logs/records/mappings/templates/os-v1/auditlogs/datastream-auditlog-v2.0.0.json
@@ -1,7 +1,6 @@
 {
   "index_patterns": ["__SEARCH_INDEX_PREFIX__auditlog*"],
   "priority": 1,
-  "data_stream": {},
   "template": {
     "settings": {
       "analysis": {
@@ -32,6 +31,7 @@
       "dynamic": "strict",
       "numeric_detection": false,
       "properties": {
+        "@timestamp": { "type": "date" },
         "id": { "type": "keyword" },
         "uuid": { "type": "keyword" },
         "version_id": { "type": "integer" },

--- a/invenio_audit_logs/records/mappings/templates/os-v2/auditlogs/datastream-auditlog-v1.0.0.json
+++ b/invenio_audit_logs/records/mappings/templates/os-v2/auditlogs/datastream-auditlog-v1.0.0.json
@@ -1,6 +1,5 @@
 {
   "index_patterns": ["__SEARCH_INDEX_PREFIX__auditlog*"],
-  "data_stream": {},
   "template": {
     "settings": {
       "analysis": {
@@ -31,6 +30,7 @@
       "dynamic": "strict",
       "numeric_detection": false,
       "properties": {
+        "@timestamp": { "type": "date" },
         "id": { "type": "keyword" },
         "uuid": { "type": "keyword" },
         "version_id": { "type": "integer" },

--- a/invenio_audit_logs/records/mappings/templates/os-v2/auditlogs/datastream-auditlog-v2.0.0.json
+++ b/invenio_audit_logs/records/mappings/templates/os-v2/auditlogs/datastream-auditlog-v2.0.0.json
@@ -1,7 +1,6 @@
 {
   "index_patterns": ["__SEARCH_INDEX_PREFIX__auditlog*"],
   "priority": 1,
-  "data_stream": {},
   "template": {
     "settings": {
       "analysis": {
@@ -32,6 +31,7 @@
       "dynamic": "strict",
       "numeric_detection": false,
       "properties": {
+        "@timestamp": { "type": "date" },
         "id": { "type": "keyword" },
         "uuid": { "type": "keyword" },
         "version_id": { "type": "integer" },

--- a/invenio_audit_logs/records/models.py
+++ b/invenio_audit_logs/records/models.py
@@ -6,6 +6,12 @@
 from invenio_db import db
 from invenio_records.models import RecordMetadataBase
 from sqlalchemy.types import String
+from sqlalchemy_utils.types import UUIDType
+
+try:
+    from uuid import uuid7
+except ImportError:
+    from uuid_utils.compat import uuid7
 
 
 class AuditLog(db.Model, RecordMetadataBase):
@@ -14,6 +20,12 @@ class AuditLog(db.Model, RecordMetadataBase):
     __tablename__ = "audit_logs_metadata"
 
     encoder = None
+
+    id = db.Column(
+        UUIDType,
+        primary_key=True,
+        default=uuid7,
+    )
 
     action = db.Column(String(255), nullable=False)
 

--- a/invenio_audit_logs/records/models.py
+++ b/invenio_audit_logs/records/models.py
@@ -20,3 +20,33 @@ class AuditLog(db.Model, RecordMetadataBase):
     resource_type = db.Column(String(255), nullable=False)
 
     user_id = db.Column(String(255), nullable=False)
+
+
+class RetentionRun(db.Model):
+    """One deleted (action, month) recorded by a retention run.
+
+    The audit log table cannot vouch for its own deletions, since it is the data
+    being removed and is itself subject to retention. This table lives apart from
+    ``audit_logs_metadata`` so it survives those deletions and stays queryable as
+    proof that the policy ran. It holds counts and status only, never event
+    content.
+    """
+
+    __tablename__ = "audit_logs_retention_runs"
+
+    id = db.Column(db.Integer, primary_key=True)
+
+    run_at = db.Column(db.DateTime, nullable=False)
+    """When the retention run executed (naive UTC)."""
+
+    action = db.Column(String(255), nullable=False)
+
+    retention_days = db.Column(db.Integer, nullable=False)
+    """The applied retention period, in days."""
+
+    month = db.Column(db.Date, nullable=False)
+    """First day of the deleted month."""
+
+    rows_deleted = db.Column(db.Integer, nullable=False)
+
+    status = db.Column(String(32), nullable=False)

--- a/invenio_audit_logs/retention.py
+++ b/invenio_audit_logs/retention.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Retention policy resolver for audit logs.
+
+The resolver maps an action id to a retention period and answers, for a given
+reference time, whether the action is kept forever and the whole-month cutoff
+before which its events have expired. It does no I/O so it can be unit tested in
+isolation.
+"""
+
+
+class _KeepForever:
+    """Sentinel marking an action whose events are never expired."""
+
+    _instance = None
+
+    def __new__(cls):
+        """Return the single shared sentinel instance."""
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self):
+        """Return repr(self)."""
+        return "KEEP_FOREVER"
+
+
+KEEP_FOREVER = _KeepForever()
+"""Retention value declaring that an action's events are kept forever."""
+
+
+def _month_start(dt):
+    """Return the first instant of ``dt``'s month, keeping its timezone."""
+    return dt.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+def _subtract_months(dt, months):
+    """Return ``dt`` shifted back by whole ``months``, wrapping across years."""
+    total = dt.year * 12 + (dt.month - 1) - months
+    year, month = divmod(total, 12)
+    return dt.replace(year=year, month=month + 1)
+
+
+class RetentionPolicy:
+    """Resolve per-action retention periods to expiry cutoffs.
+
+    Periods are configured as ``timedelta`` values and interpreted at whole-month
+    granularity, aligned to the monthly storage. A period covers as many whole
+    months as fit in its days, so 60 days keeps two months and 395 days keeps
+    thirteen.
+    """
+
+    # Approximate a month as 30 days when reducing a timedelta to whole months.
+    # The cutoff itself snaps to calendar-month boundaries, so this only decides
+    # how many months a configured period covers.
+    _days_per_month = 30
+
+    def __init__(self, periods, default):
+        """Build a resolver from a per-action mapping and a finite default."""
+        self._periods = periods
+        self._default = default
+
+    @classmethod
+    def from_config(cls, config):
+        """Build a resolver from the application config mapping."""
+        return cls(
+            periods=config["AUDIT_LOGS_RETENTION"],
+            default=config["AUDIT_LOGS_RETENTION_DEFAULT"],
+        )
+
+    def period(self, action):
+        """Return the configured period for ``action`` or the default."""
+        return self._periods.get(action, self._default)
+
+    def is_kept_forever(self, action):
+        """Whether ``action`` is exempt from expiry."""
+        return self.period(action) is KEEP_FOREVER
+
+    def cutoff(self, action, now):
+        """Return the month boundary before which ``action`` events expired.
+
+        Events with ``created`` strictly before the returned cutoff are expired.
+        Returns ``None`` when the action is kept forever.
+        """
+        period = self.period(action)
+        if period is KEEP_FOREVER:
+            return None
+        months = period.days // self._days_per_month
+        return _subtract_months(_month_start(now), months)

--- a/invenio_audit_logs/services/service.py
+++ b/invenio_audit_logs/services/service.py
@@ -6,6 +6,7 @@
 
 from datetime import datetime, timezone
 
+from invenio_db import db
 from invenio_records_resources.services.base.links import LinksTemplate
 from invenio_records_resources.services.records import RecordService
 from invenio_records_resources.services.records.schema import ServiceSchemaWrapper
@@ -20,6 +21,33 @@ from .uow import AuditRecordCommitOp
 
 class AuditLogService(RecordService):
     """Audit log service layer."""
+
+    def record_to_index(self, record):
+        """Route each event to a monthly index derived from its ``created``.
+
+        The plain ``auditlog*`` template auto-creates ``auditlog-YYYY-MM`` on first
+        write and joins it to the ``auditlog`` read alias, so there is no write
+        alias and no rollover job. Keying on the timestamp means a survivor that is
+        reindexed during retention lands back in the month it belongs to.
+        """
+        return f"auditlog-{record.created:%Y-%m}"
+
+    def reindex(self, identity, uow=None):
+        """Rebuild the search copy from PostgreSQL into the monthly indices.
+
+        PostgreSQL is authoritative, so the move off the old data stream replays
+        every row through ``record_to_index`` into its ``auditlog-YYYY-MM`` index
+        rather than copying the stream. Returns the number of events reindexed.
+        """
+        self.require_permission(identity, "search")
+        indexer = self.indexer
+        count = 0
+        for (model_id,) in db.session.query(self.record_cls.model_cls.id).all():
+            indexer.index(self.record_cls.get_record(model_id))
+            count += 1
+        if count:
+            indexer.refresh()
+        return count
 
     def _get_schema(self, action):
         """Wrap schema for the action."""

--- a/invenio_audit_logs/tasks.py
+++ b/invenio_audit_logs/tasks.py
@@ -63,14 +63,33 @@ def _delete_range(action, start, end, batch_size):
     return deleted
 
 
-def _delete_action(action, cutoff, batch_size):
-    """Delete expired events of ``action`` month by month.
+def _count_range(action, start, end):
+    """Count events of ``action`` with ``created`` in ``[start, end)``.
+
+    The dry-run counterpart to ``_delete_range``: it reads exactly the rows a real
+    run would delete, so the preview matches what enforcement removes.
+    """
+    return (
+        db.session.query(func.count(AuditLog.id))
+        .filter(
+            AuditLog.action == action,
+            AuditLog.created >= start,
+            AuditLog.created < end,
+        )
+        .scalar()
+    )
+
+
+def _expired_months(action, cutoff, batch_size, dry_run):
+    """Walk the expired months of ``action`` and report rows per month.
 
     Walks whole calendar months from the oldest expired event up to ``cutoff``,
-    which the resolver already snapped to a month boundary. Returns a list of
-    ``(month_start, rows_deleted)`` for the months that lost rows, so the caller
-    can record one retention run entry per deleted month, matching how the
-    partition-aware path will later operate on whole months.
+    which the resolver already snapped to a month boundary. A real run deletes each
+    month's rows in bounded batches; a dry run only counts them and touches
+    nothing. Returns a list of ``(month_start, rows)`` for the months with rows,
+    so the caller records one retention run entry per deleted month and reports the
+    same months in a dry run, matching how the partition-aware path will later
+    operate on whole months.
     """
     oldest = (
         db.session.query(func.min(AuditLog.created))
@@ -87,15 +106,18 @@ def _delete_action(action, cutoff, batch_size):
     month = _month_floor(oldest)
     while month < cutoff:
         following = _next_month(month)
-        deleted = _delete_range(action, month, following, batch_size)
-        if deleted:
-            per_month.append((month, deleted))
+        if dry_run:
+            rows = _count_range(action, month, following)
+        else:
+            rows = _delete_range(action, month, following, batch_size)
+        if rows:
+            per_month.append((month, rows))
         month = following
     return per_month
 
 
 @shared_task(ignore_result=True)
-def delete_expired_audit_logs():
+def delete_expired_audit_logs(dry_run=False):
     """Delete expired audit log events from PostgreSQL.
 
     For every action present in the table the resolver decides whether the action
@@ -104,8 +126,15 @@ def delete_expired_audit_logs():
     A single-run lock prevents overlapping runs, and the run is idempotent because
     a second pass finds nothing left past the cutoff.
 
-    Returns a mapping of action id to the number of rows deleted, or ``None`` when
-    another run holds the lock.
+    With ``dry_run`` the task counts what it would remove and reports it without
+    deleting any row or writing a run log entry, so an operator can validate a
+    policy change before enforcing it. The dry run reads the same months a real run
+    would, so its counts match what the next enforced run deletes.
+
+    Returns ``None`` when another run holds the lock. An enforced run returns a
+    mapping of action id to the total rows it deleted. A dry run returns a mapping
+    of action id to a per-month mapping of deleted month to the rows a real run
+    would delete.
     """
     lock = CachedMutex(LOCK_ID)
     try:
@@ -121,13 +150,16 @@ def delete_expired_audit_logs():
 
         actions = [row[0] for row in db.session.query(AuditLog.action).distinct().all()]
 
-        deleted = {}
+        report = {}
         for action in actions:
             if policy.is_kept_forever(action):
                 continue
             cutoff = policy.cutoff(action, now)
-            per_month = _delete_action(action, cutoff, batch_size)
+            per_month = _expired_months(action, cutoff, batch_size, dry_run)
             if not per_month:
+                continue
+            if dry_run:
+                report[action] = {month.date(): rows for month, rows in per_month}
                 continue
             retention_days = policy.period(action).days
             for month, deleted in per_month:
@@ -141,8 +173,9 @@ def delete_expired_audit_logs():
                         status="success",
                     )
                 )
-            deleted[action] = sum(deleted for _, deleted in per_month)
-        db.session.commit()
-        return deleted
+            report[action] = sum(deleted for _, deleted in per_month)
+        if not dry_run:
+            db.session.commit()
+        return report
     finally:
         lock.release()

--- a/invenio_audit_logs/tasks.py
+++ b/invenio_audit_logs/tasks.py
@@ -11,7 +11,7 @@ from invenio_cache.lock import CachedMutex, LockAcquireFailed
 from invenio_db import db
 from invenio_search import current_search_client
 from invenio_search.utils import build_alias_name
-from sqlalchemy import and_, func, not_, or_
+from sqlalchemy import and_, bindparam, func, not_, or_, text
 
 from .proxies import current_audit_logs_service
 from .records.models import AuditLog, RetentionRun
@@ -185,15 +185,132 @@ def _expired_months(action, cutoff, batch_size, dry_run):
     return per_month
 
 
+def _is_partitioned():
+    """Whether ``audit_logs_metadata`` is a PostgreSQL partitioned table.
+
+    Only the retention task probes this; the model and service stay unaware that
+    an operator may have partitioned the table. A partitioned parent carries the
+    ``p`` relkind in the catalog, where a plain table carries ``r``.
+    """
+    if db.engine.name != "postgresql":
+        return False
+    relkind = db.session.execute(
+        text(
+            "SELECT c.relkind FROM pg_class c "
+            "JOIN pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE c.relname = :name AND n.nspname = 'public'"
+        ),
+        {"name": AuditLog.__tablename__},
+    ).scalar()
+    return relkind == "p"
+
+
+def _partition_of_month(month, following):
+    """Return the child partition holding the ``[month, following)`` rows.
+
+    The child is found from the table OID of any row in the month rather than by
+    parsing partition bounds, so the task stays agnostic to the partition key: it
+    works whether the operator ranged the partitions on ``created`` or on a
+    time-ordered UUIDv7 id. Only cold months with rows reach here, so a row always
+    exists to read the OID from.
+    """
+    return db.session.execute(
+        text(
+            f"SELECT tableoid::regclass::text FROM {AuditLog.__tablename__} "
+            "WHERE created >= :start AND created < :end LIMIT 1"
+        ),
+        {"start": month, "end": following},
+    ).scalar()
+
+
+def _rewrite_partition(partition, expired_actions):
+    """Shrink a cold partition to its survivors inside one transaction.
+
+    Survivors are copied to a temporary table, the child partition is truncated,
+    and the survivors are reinserted, so only survivors reach the write-ahead log
+    and the ``ACCESS EXCLUSIVE`` lock stays scoped to this one cold child, never
+    the hot current month. Survivors keep their ids, so the reinserted rows route
+    back into the same partition's range.
+    """
+    survivors = text(
+        f"CREATE TEMP TABLE _audit_survivors AS "
+        f"SELECT * FROM {partition} WHERE action NOT IN :actions"
+    ).bindparams(bindparam("actions", expanding=True))
+    db.session.execute(text("DROP TABLE IF EXISTS _audit_survivors"))
+    db.session.execute(survivors, {"actions": expired_actions})
+    db.session.execute(text(f"TRUNCATE TABLE {partition}"))
+    db.session.execute(text(f"INSERT INTO {partition} SELECT * FROM _audit_survivors"))
+    db.session.execute(text("DROP TABLE _audit_survivors"))
+
+
+def _delete_partitions(finite_cutoffs, dry_run):
+    """Delete expired events from a partitioned table, one cold child at a time.
+
+    Within a cold month a row is expired exactly when its action's cutoff is later
+    than the month, so expiry is decided per action for the whole partition without
+    scanning rows. A partition whose every row is expired is truncated as a
+    metadata operation; one that still holds survivors is rewritten down to them.
+    The current (hot) month never appears, because month-aligned cutoffs leave no
+    expired rows there. Returns the same ``{action: [(month, rows)]}`` breakdown as
+    the batched fallback, so the run log and report are identical across profiles.
+    """
+    expired = _expired_clause(finite_cutoffs)
+    months = sorted(
+        {
+            _month_floor(_naive_utc(created))
+            for (created,) in db.session.query(AuditLog.created).filter(expired).all()
+        }
+    )
+
+    per_action = {}
+    for month in months:
+        following = _next_month(month)
+        expired_actions = [a for a, cutoff in finite_cutoffs.items() if month < cutoff]
+        counts = (
+            db.session.query(AuditLog.action, func.count(AuditLog.id))
+            .filter(
+                AuditLog.created >= month,
+                AuditLog.created < following,
+                AuditLog.action.in_(expired_actions),
+            )
+            .group_by(AuditLog.action)
+            .all()
+        )
+        for action, rows in counts:
+            per_action.setdefault(action, []).append((month, rows))
+
+        if dry_run:
+            continue
+
+        survivors = (
+            db.session.query(func.count(AuditLog.id))
+            .filter(
+                AuditLog.created >= month,
+                AuditLog.created < following,
+                AuditLog.action.notin_(expired_actions),
+            )
+            .scalar()
+        )
+        partition = _partition_of_month(month, following)
+        if survivors:
+            _rewrite_partition(partition, expired_actions)
+        else:
+            db.session.execute(text(f"TRUNCATE TABLE {partition}"))
+        db.session.commit()
+    return per_action
+
+
 @shared_task(ignore_result=True)
 def delete_expired_audit_logs(dry_run=False):
     """Delete expired audit log events from PostgreSQL.
 
     For every action present in the table the resolver decides whether the action
     is kept forever or yields a whole-month cutoff. Events older than the cutoff
-    are deleted in bounded batches; kept-forever and not-yet-expired events stay.
-    A single-run lock prevents overlapping runs, and the run is idempotent because
-    a second pass finds nothing left past the cutoff.
+    are removed; kept-forever and not-yet-expired events stay. Where an operator
+    has partitioned the table by month the task drops or rewrites whole cold
+    partitions, otherwise it deletes in bounded batches; both reach the same end
+    state. A single-run lock prevents overlapping runs, and the run is idempotent
+    because a second pass finds nothing left past the cutoff.
 
     With ``dry_run`` the task counts what it would remove and reports it without
     deleting any row or writing a run log entry, so an operator can validate a
@@ -231,9 +348,21 @@ def delete_expired_audit_logs(dry_run=False):
         if not dry_run and finite_cutoffs:
             _delete_from_opensearch(finite_cutoffs)
 
+        # The two profiles share retention semantics and differ only in how rows
+        # leave PostgreSQL: whole-partition operations where an operator has
+        # partitioned the table, batched DELETEs otherwise.
+        if not finite_cutoffs:
+            per_action = {}
+        elif _is_partitioned():
+            per_action = _delete_partitions(finite_cutoffs, dry_run)
+        else:
+            per_action = {
+                action: _expired_months(action, cutoff, batch_size, dry_run)
+                for action, cutoff in finite_cutoffs.items()
+            }
+
         report = {}
-        for action, cutoff in finite_cutoffs.items():
-            per_month = _expired_months(action, cutoff, batch_size, dry_run)
+        for action, per_month in per_action.items():
             if not per_month:
                 continue
             if dry_run:

--- a/invenio_audit_logs/tasks.py
+++ b/invenio_audit_logs/tasks.py
@@ -9,8 +9,11 @@ from celery import shared_task
 from flask import current_app
 from invenio_cache.lock import CachedMutex, LockAcquireFailed
 from invenio_db import db
-from sqlalchemy import func
+from invenio_search import current_search_client
+from invenio_search.utils import build_alias_name
+from sqlalchemy import and_, func, not_, or_
 
+from .proxies import current_audit_logs_service
 from .records.models import AuditLog, RetentionRun
 from .retention import RetentionPolicy
 
@@ -31,6 +34,73 @@ def _next_month(dt):
     if dt.month == 12:
         return dt.replace(year=dt.year + 1, month=1)
     return dt.replace(month=dt.month + 1)
+
+
+def _naive_utc(dt):
+    """Return ``dt`` as naive UTC to match the ``created`` column and cutoffs."""
+    if dt.tzinfo is not None:
+        return dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+def _expired_clause(finite_cutoffs):
+    """Build a filter matching every expired event across all finite actions.
+
+    An event is expired when its action has a finite period and its ``created``
+    falls before that action's cutoff. The same clause drives both the OpenSearch
+    deletion and, by negation, the survivor set, so the two stores agree on which rows
+    a run removes.
+    """
+    return or_(
+        *[
+            and_(AuditLog.action == action, AuditLog.created < cutoff)
+            for action, cutoff in finite_cutoffs.items()
+        ]
+    )
+
+
+def _delete_from_opensearch(finite_cutoffs):
+    """Drop or rebuild each month index, sourcing survivors from PostgreSQL.
+
+    Expired events are deleted from OpenSearch before PostgreSQL, so survivors are read from the
+    authoritative store while the expired rows it describes still exist. For every
+    month that holds an expired event the stale ``auditlog-YYYY-MM`` index is
+    deleted outright, so expired events vanish with their index rather than through
+    ``delete_by_query``. A month that still holds survivors is then rebuilt from
+    PostgreSQL: reindexing routes each survivor back into that same month by its
+    ``created`` timestamp.
+    """
+    expired = _expired_clause(finite_cutoffs)
+    service = current_audit_logs_service
+    indexer = service.indexer
+    record_cls = service.record_cls
+
+    months = {
+        _month_floor(_naive_utc(created))
+        for (created,) in db.session.query(AuditLog.created).filter(expired).all()
+    }
+
+    rebuilt = False
+    for month in months:
+        survivors = [
+            model_id
+            for (model_id,) in db.session.query(AuditLog.id)
+            .filter(
+                AuditLog.created >= month,
+                AuditLog.created < _next_month(month),
+                not_(expired),
+            )
+            .all()
+        ]
+        index = build_alias_name(f"auditlog-{month:%Y-%m}")
+        # Dropping the whole index removes the expired documents without
+        # delete_by_query; the template recreates and re-aliases it on first write.
+        current_search_client.indices.delete(index=index, ignore=[404])
+        for model_id in survivors:
+            indexer.index(record_cls.get_record(model_id))
+            rebuilt = True
+    if rebuilt:
+        record_cls.index.refresh()
 
 
 def _delete_range(action, start, end, batch_size):
@@ -99,8 +169,7 @@ def _expired_months(action, cutoff, batch_size, dry_run):
     if oldest is None:
         return []
     # The column reads back as UTC-aware; the cutoff and month walk are naive UTC.
-    if oldest.tzinfo is not None:
-        oldest = oldest.astimezone(timezone.utc).replace(tzinfo=None)
+    oldest = _naive_utc(oldest)
 
     per_month = []
     month = _month_floor(oldest)
@@ -135,6 +204,10 @@ def delete_expired_audit_logs(dry_run=False):
     mapping of action id to the total rows it deleted. A dry run returns a mapping
     of action id to a per-month mapping of deleted month to the rows a real run
     would delete.
+
+    Expired events are deleted from OpenSearch before PostgreSQL: a crash between the two leaves search
+    showing fewer events than the authoritative store, never more, and a later run
+    heals the drift from PostgreSQL.
     """
     lock = CachedMutex(LOCK_ID)
     try:
@@ -149,12 +222,17 @@ def delete_expired_audit_logs(dry_run=False):
         now = datetime.now(timezone.utc).replace(tzinfo=None)
 
         actions = [row[0] for row in db.session.query(AuditLog.action).distinct().all()]
+        finite_cutoffs = {
+            action: policy.cutoff(action, now)
+            for action in actions
+            if not policy.is_kept_forever(action)
+        }
+
+        if not dry_run and finite_cutoffs:
+            _delete_from_opensearch(finite_cutoffs)
 
         report = {}
-        for action in actions:
-            if policy.is_kept_forever(action):
-                continue
-            cutoff = policy.cutoff(action, now)
+        for action, cutoff in finite_cutoffs.items():
             per_month = _expired_months(action, cutoff, batch_size, dry_run)
             if not per_month:
                 continue

--- a/invenio_audit_logs/tasks.py
+++ b/invenio_audit_logs/tasks.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Celery tasks for audit log retention."""
+
+from datetime import datetime, timezone
+
+from celery import shared_task
+from flask import current_app
+from invenio_cache.lock import CachedMutex, LockAcquireFailed
+from invenio_db import db
+
+from .records.models import AuditLog
+from .retention import RetentionPolicy
+
+LOCK_ID = "audit-logs-retention"
+"""Cache key for the single-run lock guarding the retention task."""
+
+LOCK_TIMEOUT = 60 * 60 * 23
+"""Lock lifetime in seconds, below the monthly cadence so a stale lock clears."""
+
+
+def _delete_action(action, cutoff, batch_size):
+    """Delete events of ``action`` created before ``cutoff`` in bounded batches.
+
+    Deletion keys on ``created`` rather than the id, so it is independent of the
+    id version. Each batch commits on its own to keep locks and the write-ahead
+    log small on the live table.
+    """
+    deleted = 0
+    while True:
+        ids = [
+            row[0]
+            for row in db.session.query(AuditLog.id)
+            .filter(AuditLog.action == action, AuditLog.created < cutoff)
+            .limit(batch_size)
+            .all()
+        ]
+        if not ids:
+            break
+        db.session.query(AuditLog).filter(AuditLog.id.in_(ids)).delete(
+            synchronize_session=False
+        )
+        db.session.commit()
+        deleted += len(ids)
+    return deleted
+
+
+@shared_task(ignore_result=True)
+def delete_expired_audit_logs():
+    """Delete expired audit log events from PostgreSQL.
+
+    For every action present in the table the resolver decides whether the action
+    is kept forever or yields a whole-month cutoff. Events older than the cutoff
+    are deleted in bounded batches; kept-forever and not-yet-expired events stay.
+    A single-run lock prevents overlapping runs, and the run is idempotent because
+    a second pass finds nothing left past the cutoff.
+
+    Returns a mapping of action id to the number of rows deleted, or ``None`` when
+    another run holds the lock.
+    """
+    lock = CachedMutex(LOCK_ID)
+    try:
+        lock.acquire(timeout=LOCK_TIMEOUT)
+    except LockAcquireFailed:
+        return None
+
+    try:
+        policy = RetentionPolicy.from_config(current_app.config)
+        batch_size = current_app.config["AUDIT_LOGS_RETENTION_BATCH_SIZE"]
+        # The ``created`` column is naive UTC, so compare against a naive cutoff.
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+
+        actions = [row[0] for row in db.session.query(AuditLog.action).distinct().all()]
+
+        deleted = {}
+        for action in actions:
+            if policy.is_kept_forever(action):
+                continue
+            cutoff = policy.cutoff(action, now)
+            deleted = _delete_action(action, cutoff, batch_size)
+            if deleted:
+                deleted[action] = deleted
+        return deleted
+    finally:
+        lock.release()

--- a/invenio_audit_logs/tasks.py
+++ b/invenio_audit_logs/tasks.py
@@ -9,8 +9,9 @@ from celery import shared_task
 from flask import current_app
 from invenio_cache.lock import CachedMutex, LockAcquireFailed
 from invenio_db import db
+from sqlalchemy import func
 
-from .records.models import AuditLog
+from .records.models import AuditLog, RetentionRun
 from .retention import RetentionPolicy
 
 LOCK_ID = "audit-logs-retention"
@@ -20,8 +21,20 @@ LOCK_TIMEOUT = 60 * 60 * 23
 """Lock lifetime in seconds, below the monthly cadence so a stale lock clears."""
 
 
-def _delete_action(action, cutoff, batch_size):
-    """Delete events of ``action`` created before ``cutoff`` in bounded batches.
+def _month_floor(dt):
+    """Return the first instant of ``dt``'s month."""
+    return dt.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+def _next_month(dt):
+    """Return the first instant of the month after ``dt``."""
+    if dt.month == 12:
+        return dt.replace(year=dt.year + 1, month=1)
+    return dt.replace(month=dt.month + 1)
+
+
+def _delete_range(action, start, end, batch_size):
+    """Delete events of ``action`` with ``created`` in ``[start, end)``.
 
     Deletion keys on ``created`` rather than the id, so it is independent of the
     id version. Each batch commits on its own to keep locks and the write-ahead
@@ -32,7 +45,11 @@ def _delete_action(action, cutoff, batch_size):
         ids = [
             row[0]
             for row in db.session.query(AuditLog.id)
-            .filter(AuditLog.action == action, AuditLog.created < cutoff)
+            .filter(
+                AuditLog.action == action,
+                AuditLog.created >= start,
+                AuditLog.created < end,
+            )
             .limit(batch_size)
             .all()
         ]
@@ -44,6 +61,37 @@ def _delete_action(action, cutoff, batch_size):
         db.session.commit()
         deleted += len(ids)
     return deleted
+
+
+def _delete_action(action, cutoff, batch_size):
+    """Delete expired events of ``action`` month by month.
+
+    Walks whole calendar months from the oldest expired event up to ``cutoff``,
+    which the resolver already snapped to a month boundary. Returns a list of
+    ``(month_start, rows_deleted)`` for the months that lost rows, so the caller
+    can record one retention run entry per deleted month, matching how the
+    partition-aware path will later operate on whole months.
+    """
+    oldest = (
+        db.session.query(func.min(AuditLog.created))
+        .filter(AuditLog.action == action, AuditLog.created < cutoff)
+        .scalar()
+    )
+    if oldest is None:
+        return []
+    # The column reads back as UTC-aware; the cutoff and month walk are naive UTC.
+    if oldest.tzinfo is not None:
+        oldest = oldest.astimezone(timezone.utc).replace(tzinfo=None)
+
+    per_month = []
+    month = _month_floor(oldest)
+    while month < cutoff:
+        following = _next_month(month)
+        deleted = _delete_range(action, month, following, batch_size)
+        if deleted:
+            per_month.append((month, deleted))
+        month = following
+    return per_month
 
 
 @shared_task(ignore_result=True)
@@ -78,9 +126,23 @@ def delete_expired_audit_logs():
             if policy.is_kept_forever(action):
                 continue
             cutoff = policy.cutoff(action, now)
-            deleted = _delete_action(action, cutoff, batch_size)
-            if deleted:
-                deleted[action] = deleted
+            per_month = _delete_action(action, cutoff, batch_size)
+            if not per_month:
+                continue
+            retention_days = policy.period(action).days
+            for month, deleted in per_month:
+                db.session.add(
+                    RetentionRun(
+                        run_at=now,
+                        action=action,
+                        retention_days=retention_days,
+                        month=month.date(),
+                        rows_deleted=deleted,
+                        status="success",
+                    )
+                )
+            deleted[action] = sum(deleted for _, deleted in per_month)
+        db.session.commit()
         return deleted
     finally:
         lock.release()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ invenio_audit_logs = "invenio_audit_logs:InvenioAuditLogs"
 [project.entry-points."invenio_base.blueprints"]
 invenio_audit_logs_ext = "invenio_audit_logs.views:blueprint"
 
+[project.entry-points."invenio_celery.tasks"]
+invenio_audit_logs = "invenio_audit_logs.tasks"
+
 [project.entry-points."invenio_db.alembic"]
 invenio_audit_logs = "invenio_audit_logs:alembic"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "invenio-i18n>=4.0.0,<5.0.0",
   "invenio-indexer>=6.0.0,<7.0.0",
   "invenio-records-resources>=11.0.0,<12.0.0",
+  "uuid-utils>=0.11.1; python_version < '3.14'",
 ]
 dynamic = ["version"]
 

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -14,8 +14,11 @@ from invenio_access.permissions import authenticated_user, system_user_id
 from invenio_accounts.testutils import login_user_via_session
 from invenio_app.factory import create_api
 from invenio_search import current_search
+from sqlalchemy import MetaData, PrimaryKeyConstraint, text
+from sqlalchemy.schema import CreateTable, DropTable
 
 from invenio_audit_logs.proxies import current_audit_logs_service
+from invenio_audit_logs.records.models import AuditLog
 
 
 @pytest.fixture(scope="module")
@@ -34,6 +37,49 @@ def setup_index_templates(app):
 def service(appctx):
     """Fixture for the current service."""
     return current_audit_logs_service
+
+
+@pytest.fixture()
+def partition_audit_table(db):
+    """Re-create ``audit_logs_metadata`` as a partitioned table built from the model.
+
+    PostgreSQL decides partitioning when the table is created, and the model does not
+    say anything about partitioning (and should not). So this drops the plain table
+    and builds it again from the model's own columns, adding only the partitioning
+    parts: the ``PARTITION BY`` clause, the primary key (which has to include the
+    partition key), and the child partitions. Because the columns come from the
+    model, the test never repeats the schema and stays in sync with the model. It all
+    runs in the test's transaction, so the table goes back to normal when the test
+    ends.
+
+    ``children`` maps each child partition name to its ``(from, to)`` range. Pass
+    ``primary_key`` when the partition key has to be part of the primary key (which
+    PostgreSQL requires); leave it out to keep the model's primary key.
+    """
+    if db.engine.name != "postgresql":
+        pytest.skip("Partitioning only runs on PostgreSQL")
+
+    def _partition(partition_by, children, primary_key=None):
+        clone = AuditLog.__table__.to_metadata(MetaData())
+        if primary_key is not None:
+            clone.constraints = {
+                c for c in clone.constraints if not isinstance(c, PrimaryKeyConstraint)
+            }
+            clone.append_constraint(PrimaryKeyConstraint(*primary_key))
+        clone.dialect_options["postgresql"]["partition_by"] = partition_by
+
+        db.session.execute(DropTable(AuditLog.__table__))
+        db.session.execute(CreateTable(clone))
+        for name, (start, end) in children.items():
+            db.session.execute(
+                text(
+                    f"CREATE TABLE {name} PARTITION OF audit_logs_metadata "
+                    f"FOR VALUES FROM ('{start}') TO ('{end}')"
+                )
+            )
+        db.session.commit()
+
+    return _partition
 
 
 @pytest.fixture(scope="function")

--- a/tests/services/test_action_builder.py
+++ b/tests/services/test_action_builder.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 """Test audit log builder."""
 
-import pytest
 from flask import g
 from flask_login import login_user
 from invenio_access.permissions import system_identity

--- a/tests/services/test_opensearch_monthly.py
+++ b/tests/services/test_opensearch_monthly.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the monthly OpenSearch storage of audit logs.
+
+The search copy lives in plain ``auditlog-YYYY-MM`` indices behind the
+``auditlog`` read alias instead of a managed data stream. These tests assert the
+external behaviour: where new writes land, that search through the alias spans
+every month, that existing PostgreSQL rows reindex into the monthly layout
+without loss, and that no data stream, write alias, or rollover job is involved.
+"""
+
+from datetime import datetime, timezone
+
+from invenio_access.permissions import system_identity
+from invenio_db import db
+from invenio_search import current_search_client
+from invenio_search.utils import build_alias_name
+
+from invenio_audit_logs.records.models import AuditLog
+
+
+def _month_index(dt):
+    """Return the prefixed name of the monthly index for ``dt``."""
+    return build_alias_name(f"auditlog-{dt:%Y-%m}")
+
+
+def _months_before(dt, n):
+    """Return ``dt`` shifted back by whole ``n`` months."""
+    total = dt.year * 12 + (dt.month - 1) - n
+    year, month = divmod(total, 12)
+    return dt.replace(
+        year=year, month=month + 1, day=1, hour=0, minute=0, second=0, microsecond=0
+    )
+
+
+def _insert(action, created, resource_id):
+    """Insert an audit log row straight into PostgreSQL with a chosen month.
+
+    Bypasses the service so the row exists only in PostgreSQL, mimicking history
+    that predates the monthly indices and must be reindexed into them.
+    """
+    row = AuditLog(
+        action=action,
+        resource_type="record",
+        user_id="1",
+        json={
+            "resource": {"type": "record", "id": resource_id},
+            "user": {
+                "id": "1",
+                "username": "User",
+                "email": "user@inveniosoftware.org",
+            },
+            "message": "event",
+            "metadata": {},
+        },
+        created=created,
+        updated=created,
+    )
+    db.session.add(row)
+    db.session.commit()
+    return row.id
+
+
+def _auditlog_templates():
+    """Return the registered index templates that match ``auditlog*``."""
+    templates = current_search_client.indices.get_index_template(name="*auditlog*")
+    return [
+        entry
+        for entry in templates["index_templates"]
+        if any("auditlog" in p for p in entry["index_template"]["index_patterns"])
+    ]
+
+
+def test_template_declares_no_data_stream(app):
+    """The auditlog index templates are plain templates, not data streams."""
+    with app.app_context():
+        templates = _auditlog_templates()
+        assert templates  # the template is registered at all
+        for entry in templates:
+            assert "data_stream" not in entry["index_template"]
+
+
+def test_write_lands_in_monthly_index_under_read_alias(app, db, service, resource_data):
+    """A new write creates ``auditlog-YYYY-MM`` and joins it to the read alias."""
+    # The OpenSearch copy outlives a single test, so a unique resource id keeps
+    # this event from colliding with other tests' draft.create events.
+    resource_data["resource"]["id"] = "monthly-write"
+    with app.test_request_context():
+        service.create(identity=system_identity, data=resource_data)
+    service.record_cls.index.refresh()
+
+    now = datetime.now(timezone.utc)
+    month_index = _month_index(now)
+    alias = build_alias_name("auditlog")
+    client = current_search_client
+
+    # The month index was auto-created on first write.
+    assert client.indices.exists(index=month_index)
+    # ...and the read alias points at it with no write-index flag (no write alias).
+    alias_entry = client.indices.get_alias(index=month_index)[month_index]["aliases"]
+    assert alias in alias_entry
+    assert alias_entry[alias].get("is_write_index") is not True
+
+    # The event is searchable through the alias.
+    found = service.search(
+        identity=system_identity,
+        params={"q": "resource.id: monthly-write AND action: draft.create"},
+    )
+    assert found.total == 1
+
+
+def test_no_data_stream_or_rollover(app, db, service, resource_data):
+    """Writing creates no data stream and needs no rollover job."""
+    resource_data["resource"]["id"] = "monthly-no-stream"
+    with app.test_request_context():
+        service.create(identity=system_identity, data=resource_data)
+    service.record_cls.index.refresh()
+
+    client = current_search_client
+    assert client.indices.get_data_stream(name="*auditlog*")["data_streams"] == []
+
+
+def test_reindex_spreads_existing_data_across_months(app, db, service):
+    """Reindexing routes each PostgreSQL row into its own month with no loss."""
+    with app.app_context():
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        this_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        months = {
+            "current": (this_month, "monthly-current"),
+            "five_back": (_months_before(this_month, 5), "monthly-five-back"),
+            "twenty_back": (_months_before(this_month, 20), "monthly-twenty-back"),
+        }
+        for created, rid in months.values():
+            _insert("draft.create", created, rid)
+
+        reindexed = service.reindex(identity=system_identity)
+        assert reindexed == 3
+        service.record_cls.index.refresh()
+
+        client = current_search_client
+        # Each row landed in the index for its own month, and nowhere else.
+        for created, rid in months.values():
+            index = _month_index(created)
+            hits = client.search(
+                index=index,
+                body={"query": {"term": {"resource.id": rid}}},
+            )
+            assert hits["hits"]["total"]["value"] == 1
+
+        # Search through the alias spans all three months with no duplicates.
+        for created, rid in months.values():
+            found = service.search(
+                identity=system_identity,
+                params={"q": f"resource.id: {rid} AND action: draft.create"},
+            )
+            assert found.total == 1
+
+        all_hits = service.search(
+            identity=system_identity,
+            params={"q": "action: draft.create", "size": 100},
+        )
+        seen = {hit["resource"]["id"] for hit in all_hits.hits}
+        assert {rid for _, rid in months.values()} <= seen

--- a/tests/services/test_partitioned_compatibility.py
+++ b/tests/services/test_partitioned_compatibility.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Check the module works on a table partitioned by the UUIDv7 id.
+
+A UUIDv7 starts with its creation time, so an operator can partition the table by
+time using the id alone, with a tool like ``pg_partman`` and no extra column. These
+tests create such a table and check that create, read, search, and the model still
+work, because the module should not need to know the table is partitioned. The
+retention side of this is in ``test_retention_partitioned.py``.
+"""
+
+import copy
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from invenio_access.permissions import system_identity
+from invenio_db import db
+from invenio_search import current_search_client
+from sqlalchemy import text
+
+from invenio_audit_logs.records.models import AuditLog
+
+
+def _next_month(month_start):
+    """Return the first day of the month after ``month_start``."""
+    if month_start.month == 12:
+        return month_start.replace(year=month_start.year + 1, month=1)
+    return month_start.replace(month=month_start.month + 1)
+
+
+def _uuid7_floor(month_start):
+    """The smallest UUIDv7 for the start of a month, used as a partition boundary.
+
+    It puts the month's millisecond timestamp at the front and zeros after it, so
+    any real UUIDv7 from that month is equal to or greater than it.
+    """
+    ms = int(month_start.replace(tzinfo=timezone.utc).timestamp() * 1000)
+    hexed = f"{ms:012x}"
+    return f"{hexed[:8]}-{hexed[8:12]}-7000-8000-000000000000"
+
+
+def _clear_audit_indices():
+    """Delete the monthly ``auditlog`` indices so their documents don't reach other tests."""
+    current_search_client.indices.delete(index="auditlog*", ignore_unavailable=True)
+
+
+@pytest.fixture()
+def partition_table(app, db, partition_audit_table):
+    """Partition ``audit_logs_metadata`` by the UUIDv7 id, one child per month.
+
+    ``partition_audit_table`` builds the table from the model; here we only list the
+    monthly id ranges. These tests write through the service, so the search indices
+    they fill are deleted at the end to keep their documents out of later tests.
+    """
+    with app.app_context():
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        curr_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        prev_month = (curr_month - timedelta(days=1)).replace(day=1)
+        next_month = _next_month(curr_month)
+        following_month = _next_month(next_month)
+
+        children = {
+            f"audit_logs_metadata_y{start.year}_m{start.month:02d}": (
+                _uuid7_floor(start),
+                _uuid7_floor(end),
+            )
+            for start, end in (
+                (prev_month, curr_month),
+                (curr_month, next_month),
+                (next_month, following_month),
+            )
+        }
+        partition_audit_table("RANGE (id)", children)
+
+        _clear_audit_indices()
+        yield
+        _clear_audit_indices()
+
+
+def test_basic_crud_with_partitioned_table(
+    app, service, resource_data, client_with_login, partition_table
+):
+    """Create and read a log entry on the partitioned table."""
+    with app.test_request_context():
+        created = service.create(identity=system_identity, data=resource_data)
+        fetched = service.read(identity=system_identity, id_=created.id)
+
+    assert fetched["action"] == "draft.create"
+    assert fetched["resource"]["id"] == "abcd-1234"
+    assert fetched["user"]["id"] == "1"
+
+
+def test_cross_partition_queries(
+    app, service, resource_data, client_with_login, partition_table
+):
+    """Read several entries back and count them across the partitioned table."""
+    with app.test_request_context():
+        ids = []
+        for n in range(1, 4):
+            data = copy.deepcopy(resource_data)
+            data["resource"]["id"] = f"resource-{n}"
+            ids.append(service.create(identity=system_identity, data=data).id)
+
+        for n, id_ in enumerate(ids, start=1):
+            assert (
+                service.read(identity=system_identity, id_=id_)["resource"]["id"]
+                == f"resource-{n}"
+            )
+
+        count = db.session.execute(
+            text("SELECT count(*) FROM audit_logs_metadata")
+        ).scalar()
+        assert count == 3
+
+
+def test_search_with_partitioned_table(
+    app, service, resource_data, client_with_login, partition_table
+):
+    """Index a log entry on the partitioned table and find it through search."""
+    data = copy.deepcopy(resource_data)
+    data["resource"]["id"] = "search-test-unique-id"
+
+    with app.test_request_context():
+        service.create(identity=system_identity, data=data)
+        service.record_cls.index.refresh()
+
+        results = service.search(
+            identity=system_identity,
+            params={"q": "resource.id: search-test-unique-id"},
+        )
+
+    assert results.total == 1
+    hits = list(results.hits)
+    assert hits[0]["resource"]["id"] == "search-test-unique-id"
+
+
+def test_model_unaware_of_partitioning(app, partition_table):
+    """The model still maps to one plain table with a single-column id key."""
+    assert AuditLog.__tablename__ == "audit_logs_metadata"
+    assert AuditLog.__table__.primary_key.columns.keys() == ["id"]
+
+    table = db.metadata.tables["audit_logs_metadata"]
+    assert {"id", "created", "action", "resource_type", "user_id"} <= set(
+        table.columns.keys()
+    )
+
+
+def test_partition_count(app, partition_table):
+    """The previous, current, and next month each get a child partition."""
+    partitions = db.session.execute(
+        text(
+            "SELECT tablename FROM pg_tables "
+            "WHERE tablename LIKE 'audit_logs_metadata_y%' ORDER BY tablename"
+        )
+    ).fetchall()
+    names = [row[0] for row in partitions]
+
+    assert len(names) == 3
+    assert all(
+        name.startswith("audit_logs_metadata_y") and "_m" in name for name in names
+    )

--- a/tests/services/test_retention.py
+++ b/tests/services/test_retention.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Tests for audit log retention: resolver and the monthly DB delete."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from invenio_cache.lock import CachedMutex
+from invenio_db import db
+
+from invenio_audit_logs import KEEP_FOREVER
+from invenio_audit_logs.records.models import AuditLog
+from invenio_audit_logs.retention import RetentionPolicy
+from invenio_audit_logs.tasks import LOCK_ID, delete_expired_audit_logs
+
+NOW = datetime(2026, 9, 15, 12, 30)
+UTC = timezone.utc
+
+
+@pytest.mark.parametrize(
+    "action, periods, default, expected",
+    [
+        # Explicit per-action period: 60 days -> two whole months.
+        (
+            "user.login",
+            {"user.login": timedelta(days=60)},
+            timedelta(days=395),
+            datetime(2026, 7, 1),
+        ),
+        # Default fallback: 395 days -> thirteen whole months.
+        (
+            "record.publish",
+            {},
+            timedelta(days=395),
+            datetime(2025, 8, 1),
+        ),
+        # Kept forever: no cutoff.
+        (
+            "user.block",
+            {"user.block": KEEP_FOREVER},
+            timedelta(days=395),
+            None,
+        ),
+    ],
+)
+def test_resolver_cutoff(action, periods, default, expected):
+    """Resolver returns kept-forever or a whole-month cutoff per action."""
+    policy = RetentionPolicy(periods, default)
+    assert policy.cutoff(action, NOW) == expected
+
+
+@pytest.mark.parametrize(
+    "now, period, expected",
+    [
+        # Crossing a year boundary backwards.
+        (datetime(2026, 1, 10), timedelta(days=60), datetime(2025, 11, 1)),
+        # End-of-month reference still snaps to the first of the month.
+        (datetime(2026, 3, 31, 23, 59), timedelta(days=90), datetime(2025, 12, 1)),
+        # One month back from December.
+        (datetime(2026, 12, 1), timedelta(days=30), datetime(2026, 11, 1)),
+    ],
+)
+def test_resolver_month_boundary(now, period, expected):
+    """The cutoff lands on a calendar-month boundary across year wraps."""
+    policy = RetentionPolicy({"action": period}, timedelta(days=395))
+    assert policy.cutoff("action", now) == expected
+
+
+def test_resolver_keep_forever_flag():
+    """is_kept_forever distinguishes the sentinel from a finite period."""
+    policy = RetentionPolicy({"user.block": KEEP_FOREVER}, timedelta(days=395))
+    assert policy.is_kept_forever("user.block") is True
+    assert policy.is_kept_forever("user.login") is False
+
+
+def _months_before(month_start, n):
+    """Return the start of the month ``n`` months before ``month_start``."""
+    total = month_start.year * 12 + (month_start.month - 1) - n
+    year, month = divmod(total, 12)
+    return month_start.replace(year=year, month=month + 1)
+
+
+def _insert(action, created):
+    """Insert an audit log row with a chosen ``created`` timestamp."""
+    row = AuditLog(
+        action=action,
+        resource_type="record",
+        user_id="1",
+        json={},
+        created=created,
+        updated=created,
+    )
+    db.session.add(row)
+    db.session.commit()
+    return row.id
+
+
+@pytest.fixture()
+def retention_config(set_app_config_fn_scoped):
+    """Two-month logins, kept-forever blocks, 13-month default."""
+    set_app_config_fn_scoped(
+        {
+            "AUDIT_LOGS_RETENTION": {
+                "user.login": timedelta(days=60),
+                "user.block": KEEP_FOREVER,
+            },
+            "AUDIT_LOGS_RETENTION_DEFAULT": timedelta(days=395),
+        }
+    )
+
+
+@pytest.fixture()
+def seeded_events(app, db, retention_config):
+    """Seed events across months and actions with mixed retention."""
+    with app.app_context():
+        now = datetime.now(UTC).replace(tzinfo=None)
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+        ids = {
+            # Past the two-month login cutoff -> expired.
+            "old_login": _insert("user.login", _months_before(month_start, 5)),
+            # Current month -> within period, kept.
+            "recent_login": _insert("user.login", now),
+            # Kept forever regardless of age.
+            "old_block": _insert("user.block", _months_before(month_start, 10)),
+            # Within the 13-month default -> kept.
+            "publish_recent": _insert("record.publish", _months_before(month_start, 5)),
+            # Past the 13-month default -> expired.
+            "publish_old": _insert("record.publish", _months_before(month_start, 20)),
+        }
+        yield ids
+
+
+def _remaining_ids():
+    """Return the set of ids currently in the table."""
+    return {row[0] for row in db.session.query(AuditLog.id).all()}
+
+
+def test_deletes_only_expired(app, seeded_events):
+    """Only events past their action's cutoff are deleted; the rest remain."""
+    with app.app_context():
+        deleted = delete_expired_audit_logs()
+
+        assert deleted == {"user.login": 1, "record.publish": 1}
+        assert _remaining_ids() == {
+            seeded_events["recent_login"],
+            seeded_events["old_block"],
+            seeded_events["publish_recent"],
+        }
+
+
+def test_delete_is_idempotent(app, seeded_events):
+    """A second run deletes nothing and leaves the survivors untouched."""
+    with app.app_context():
+        delete_expired_audit_logs()
+        survivors = _remaining_ids()
+
+        deleted = delete_expired_audit_logs()
+
+        assert deleted == {}
+        assert _remaining_ids() == survivors
+
+
+def test_delete_respects_single_run_lock(app, seeded_events):
+    """A held lock blocks the run, so nothing is deleted."""
+    with app.app_context():
+        before = _remaining_ids()
+        lock = CachedMutex(LOCK_ID)
+        lock.acquire(timeout=60)
+        try:
+            deleted = delete_expired_audit_logs()
+        finally:
+            lock.release()
+
+        assert deleted is None
+        assert _remaining_ids() == before

--- a/tests/services/test_retention.py
+++ b/tests/services/test_retention.py
@@ -6,6 +6,7 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from invenio_access.permissions import system_identity
 from invenio_cache.lock import CachedMutex
 from invenio_db import db
 
@@ -257,3 +258,81 @@ def test_run_log_persists_across_runs(app, seeded_events):
         assert deleted == {}
         assert {(run.action, run.month, run.rows_deleted) for run in _runs()} == first
         assert len(first) == 2
+
+
+def test_dry_run_reports_per_action_and_month(app, seeded_events):
+    """A dry run reports the expired rows broken down by action and month."""
+    with app.app_context():
+        now = datetime.now(UTC).replace(tzinfo=None)
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+        report = delete_expired_audit_logs(dry_run=True)
+
+        assert report == {
+            "user.login": {_months_before(month_start, 5).date(): 1},
+            "record.publish": {_months_before(month_start, 20).date(): 1},
+        }
+
+
+def test_dry_run_deletes_nothing_in_postgres(app, seeded_events):
+    """A dry run leaves every PostgreSQL row in place, expired or not."""
+    with app.app_context():
+        before = _remaining_ids()
+
+        delete_expired_audit_logs(dry_run=True)
+
+        assert _remaining_ids() == before
+        # Reporting only; nothing claims a run happened.
+        assert _runs() == []
+
+
+def test_dry_run_counts_match_real_run(app, seeded_events):
+    """The dry-run preview equals what the next enforced run actually deletes."""
+    with app.app_context():
+        report = delete_expired_audit_logs(dry_run=True)
+
+        deleted = delete_expired_audit_logs()
+
+        # Per-action totals reported by the dry run match the rows deleted.
+        assert deleted == {
+            action: sum(months.values()) for action, months in report.items()
+        }
+        # Per-month counts reported by the dry run match the run log entries.
+        assert {(run.action, run.month, run.rows_deleted) for run in _runs()} == {
+            (action, month, rows)
+            for action, months in report.items()
+            for month, rows in months.items()
+        }
+
+
+def test_dry_run_leaves_opensearch_searchable(app, service, resource_data):
+    """A dry run touches no OpenSearch document, so expired events stay indexed."""
+    with app.app_context():
+        now = datetime.now(UTC).replace(tzinfo=None)
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        expired = _months_before(month_start, 20)
+
+        # Create the event through the service so it lands in OpenSearch too, then
+        # backdate the row in PostgreSQL. draft.create has no explicit period, so it
+        # falls under the 13-month default and a 20-month-old event is expired. The
+        # search index outlives a single test, so a unique resource id keeps this
+        # event from colliding with other tests' draft.create events.
+        resource_data["resource"]["id"] = "retention-dry-run"
+        with app.test_request_context():
+            service.create(identity=system_identity, data=resource_data)
+        db.session.query(AuditLog).update(
+            {AuditLog.created: expired, AuditLog.updated: expired}
+        )
+        db.session.commit()
+        service.record_cls.index.refresh()
+
+        report = delete_expired_audit_logs(dry_run=True)
+        assert report == {"draft.create": {expired.date(): 1}}
+
+        # The expired event is still in PostgreSQL and still searchable.
+        assert len(_remaining_ids()) == 1
+        found = service.search(
+            identity=system_identity,
+            params={"q": "resource.id: retention-dry-run AND action: draft.create"},
+        )
+        assert found.total == 1

--- a/tests/services/test_retention.py
+++ b/tests/services/test_retention.py
@@ -10,7 +10,7 @@ from invenio_cache.lock import CachedMutex
 from invenio_db import db
 
 from invenio_audit_logs import KEEP_FOREVER
-from invenio_audit_logs.records.models import AuditLog
+from invenio_audit_logs.records.models import AuditLog, RetentionRun
 from invenio_audit_logs.retention import RetentionPolicy
 from invenio_audit_logs.tasks import LOCK_ID, delete_expired_audit_logs
 
@@ -175,3 +175,85 @@ def test_delete_respects_single_run_lock(app, seeded_events):
 
         assert deleted is None
         assert _remaining_ids() == before
+
+
+def _runs():
+    """Return the retention run log entries, ordered for stable assertions."""
+    return (
+        db.session.query(RetentionRun)
+        .order_by(RetentionRun.action, RetentionRun.month)
+        .all()
+    )
+
+
+def test_run_log_records_each_deleted_month(app, seeded_events):
+    """One entry per deleted (action, month) carries its count, period, status."""
+    with app.app_context():
+        now = datetime.now(UTC).replace(tzinfo=None)
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+        delete_expired_audit_logs()
+
+        by_action = {run.action: run for run in _runs()}
+        assert set(by_action) == {"user.login", "record.publish"}
+
+        login = by_action["user.login"]
+        assert login.month == _months_before(month_start, 5).date()
+        assert login.rows_deleted == 1
+        assert login.retention_days == 60
+        assert login.status == "success"
+        assert isinstance(login.run_at, datetime)
+
+        publish = by_action["record.publish"]
+        assert publish.month == _months_before(month_start, 20).date()
+        assert publish.rows_deleted == 1
+        assert publish.retention_days == 395
+        assert publish.status == "success"
+
+
+def test_run_log_one_entry_per_month_per_action(app, db, retention_config):
+    """Expired rows of one action spread over months yield one entry each."""
+    with app.app_context():
+        now = datetime.now(UTC).replace(tzinfo=None)
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+        # Two rows in the same expired month, one in an older expired month.
+        _insert("user.login", _months_before(month_start, 4))
+        _insert("user.login", _months_before(month_start, 4) + timedelta(days=1))
+        _insert("user.login", _months_before(month_start, 6))
+
+        delete_expired_audit_logs()
+
+        logins = [run for run in _runs() if run.action == "user.login"]
+        assert {(run.month, run.rows_deleted) for run in logins} == {
+            (_months_before(month_start, 4).date(), 2),
+            (_months_before(month_start, 6).date(), 1),
+        }
+
+
+def test_run_log_holds_no_event_content():
+    """The run log table carries counts and status only, no event payload."""
+    assert set(RetentionRun.__table__.columns.keys()) == {
+        "id",
+        "run_at",
+        "action",
+        "retention_days",
+        "month",
+        "rows_deleted",
+        "status",
+    }
+
+
+def test_run_log_persists_across_runs(app, seeded_events):
+    """Entries survive the deletion and a later no-op run, proving enforcement."""
+    with app.app_context():
+        delete_expired_audit_logs()
+        first = {(run.action, run.month, run.rows_deleted) for run in _runs()}
+
+        # A second run deletes nothing, yet the earlier proof stays in its own
+        # table even though the audit rows it describes are gone.
+        deleted = delete_expired_audit_logs()
+
+        assert deleted == {}
+        assert {(run.action, run.month, run.rows_deleted) for run in _runs()} == first
+        assert len(first) == 2

--- a/tests/services/test_retention_opensearch.py
+++ b/tests/services/test_retention_opensearch.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the OpenSearch side of audit log retention.
+
+The retention task deletes the search copy before PostgreSQL. A month with no
+survivors has its whole ``auditlog-YYYY-MM`` index dropped; a month that still
+holds survivors is rebuilt from PostgreSQL, the source of truth. No
+``delete_by_query`` is used. These tests assert the external behaviour: which
+events stay searchable after a run, that a barren month index is gone while a
+month with survivors is a fresh index holding only them, and that the rebuild
+reflects PostgreSQL rather than the index's prior contents.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from invenio_access.permissions import system_identity
+from invenio_db import db
+from invenio_search import current_search_client
+from invenio_search.utils import build_alias_name
+
+from invenio_audit_logs import KEEP_FOREVER
+from invenio_audit_logs.records.models import AuditLog
+from invenio_audit_logs.tasks import delete_expired_audit_logs
+
+UTC = timezone.utc
+
+
+def _months_before(dt, n):
+    """Return the start of the month ``n`` months before ``dt``."""
+    total = dt.year * 12 + (dt.month - 1) - n
+    year, month = divmod(total, 12)
+    return dt.replace(
+        year=year, month=month + 1, day=1, hour=0, minute=0, second=0, microsecond=0
+    )
+
+
+def _month_index(dt):
+    """Return the prefixed name of the monthly index for ``dt``."""
+    return build_alias_name(f"auditlog-{dt:%Y-%m}")
+
+
+def _index_uuid(name):
+    """Return the OpenSearch uuid of index ``name``, or ``None`` if absent."""
+    info = current_search_client.indices.get(index=name, ignore=[404])
+    if name not in info:
+        return None
+    return info[name]["settings"]["index"]["uuid"]
+
+
+def _make_event(service, action, created, resource_id):
+    """Create an event in both PostgreSQL and its monthly OpenSearch index."""
+    row = AuditLog(
+        action=action,
+        resource_type="record",
+        user_id="1",
+        json={
+            "resource": {"type": "record", "id": resource_id},
+            "user": {
+                "id": "1",
+                "username": "User",
+                "email": "user@inveniosoftware.org",
+            },
+            "message": "event",
+            "metadata": {},
+        },
+        created=created,
+        updated=created,
+    )
+    db.session.add(row)
+    db.session.commit()
+    service.indexer.index(service.record_cls.get_record(row.id))
+    return row.id
+
+
+def _found(service, resource_id, action):
+    """Return how many events match ``resource_id`` and ``action`` via the alias."""
+    result = service.search(
+        identity=system_identity,
+        params={"q": f"resource.id: {resource_id} AND action: {action}"},
+    )
+    return result.total
+
+
+def _pg_ids():
+    """Return the set of audit log ids currently in PostgreSQL."""
+    return {row[0] for row in db.session.query(AuditLog.id).all()}
+
+
+@pytest.fixture()
+def keep_publish_forever(set_app_config_fn_scoped):
+    """Keep ``record.publish`` forever; everything else uses the 13-month default."""
+    set_app_config_fn_scoped({"AUDIT_LOGS_RETENTION": {"record.publish": KEEP_FOREVER}})
+
+
+def test_expired_disappear_and_survivors_remain(app, db, service, keep_publish_forever):
+    """Expired events vanish from both stores; survivors stay searchable.
+
+    A barren expired month is dropped outright, while a month sharing an expired
+    event with a kept-forever survivor is rebuilt down to that survivor.
+    """
+    with app.app_context():
+        now = datetime.now(UTC).replace(tzinfo=None)
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+        barren = _months_before(month_start, 25)  # only an expired draft.create
+        mixed = _months_before(month_start, 20)  # expired draft + kept-forever publish
+        recent = _months_before(month_start, 2)  # within the 13-month default
+
+        ids = {
+            "barren_draft": _make_event(service, "draft.create", barren, "os-barren"),
+            "mixed_draft": _make_event(
+                service, "draft.create", mixed, "os-mixed-draft"
+            ),
+            "mixed_publish": _make_event(
+                service, "record.publish", mixed, "os-mixed-publish"
+            ),
+            "recent_draft": _make_event(service, "draft.create", recent, "os-recent"),
+        }
+        service.record_cls.index.refresh()
+
+        # The mixed month is rebuilt, so its index identity must change; the barren
+        # month is dropped, so its index must be gone afterwards.
+        mixed_uuid_before = _index_uuid(_month_index(mixed))
+
+        delete_expired_audit_logs()
+        current_search_client.indices.refresh(
+            index=build_alias_name("auditlog-*"), ignore=[404]
+        )
+
+        # PostgreSQL keeps exactly the survivors.
+        assert _pg_ids() == {ids["mixed_publish"], ids["recent_draft"]}
+
+        # Expired events are no longer searchable.
+        assert _found(service, "os-barren", "draft.create") == 0
+        assert _found(service, "os-mixed-draft", "draft.create") == 0
+        # Kept-forever and within-period events remain searchable.
+        assert _found(service, "os-mixed-publish", "record.publish") == 1
+        assert _found(service, "os-recent", "draft.create") == 1
+
+        # The barren month index is deleted; the mixed month is a fresh index.
+        assert _index_uuid(_month_index(barren)) is None
+        mixed_uuid_after = _index_uuid(_month_index(mixed))
+        assert mixed_uuid_after is not None
+        assert mixed_uuid_after != mixed_uuid_before
+
+
+def test_rebuild_reconciles_from_postgres(app, db, service, keep_publish_forever):
+    """A rebuilt month mirrors PostgreSQL, not the index's earlier contents.
+
+    Expired events are deleted from OpenSearch before PostgreSQL, and OpenSearch is rebuilt from it, so a document with
+    no backing row is dropped even though, taken alone, it looks like a survivor.
+    """
+    with app.app_context():
+        now = datetime.now(UTC).replace(tzinfo=None)
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        month = _months_before(month_start, 30)
+
+        # An expired draft triggers processing of the month; a kept-forever publish
+        # is indexed alongside it and then removed from PostgreSQL only, leaving an
+        # orphan that survives in OpenSearch until the rebuild reconciles the month.
+        _make_event(service, "draft.create", month, "os-orphan-draft")
+        orphan = _make_event(service, "record.publish", month, "os-orphan-publish")
+        service.record_cls.index.refresh()
+
+        db.session.query(AuditLog).filter(AuditLog.id == orphan).delete(
+            synchronize_session=False
+        )
+        db.session.commit()
+        # The orphan is still searchable before the run.
+        assert _found(service, "os-orphan-publish", "record.publish") == 1
+
+        delete_expired_audit_logs()
+        current_search_client.indices.refresh(
+            index=build_alias_name("auditlog-*"), ignore=[404]
+        )
+
+        # PostgreSQL holds nothing for this month, so the rebuilt search copy does
+        # not either: the orphan is gone and the month index dropped entirely.
+        assert _found(service, "os-orphan-draft", "draft.create") == 0
+        assert _found(service, "os-orphan-publish", "record.publish") == 0
+        assert _index_uuid(_month_index(month)) is None

--- a/tests/services/test_retention_partitioned.py
+++ b/tests/services/test_retention_partitioned.py
@@ -1,21 +1,19 @@
 # SPDX-FileCopyrightText: 2026 CERN.
 # SPDX-License-Identifier: MIT
 
-"""Retention against a monthly-partitioned ``audit_logs_metadata``.
+"""Retention on a month-partitioned ``audit_logs_metadata`` table.
 
-The default profile deletes scattered rows in batches; the scale profile lets an
-operator partition the table by month and the task then drops or rewrites whole
-cold partitions instead. Both profiles must reach the same end state, so these
-tests seed an operator-style partitioned table and assert the same survivors the
-batched path produces, plus that the rewrite touches only cold children.
+By default retention deletes old rows in batches. If an operator partitions the
+table by month, the task drops or rewrites whole old partitions instead. Both ways
+must end up with the same rows, so these tests set up a partitioned table and check
+that the kept rows match the batched version and that only old partitions are
+touched.
 
-The fixture partitions on ``created`` rather than the UUIDv7 id used by the
-prior-art ``test_partitioned_compatibility.py``. Until the id migration lands the
-model still issues uuid4 ids, which would fall outside any id-based partition
-range; partitioning on ``created`` matches how retention keys its cutoffs and
-keeps the task's partition handling agnostic to the partition key. The setup runs
-inside the test's own transaction, so the savepoint-based ``db`` fixture rolls the
-table back to a plain table after each test with no leakage.
+The table is partitioned by ``created``, not by the UUIDv7 id, because the tests
+insert rows with old ``created`` times while their ids are generated at insert time.
+Partitioning by ``created`` puts each row in the right month. ``partition_audit_table``
+builds the table from the model, so only the monthly ranges are here. The setup runs
+in the test's transaction, so the table goes back to normal after each test.
 """
 
 from datetime import datetime, timedelta, timezone
@@ -79,11 +77,11 @@ def _partition_names():
 
 @pytest.fixture()
 def retention_config(set_app_config_fn_scoped):
-    """Two-month logins, kept-forever blocks, 13-month default.
+    """Logins kept 2 months, blocks kept forever, everything else 13 months.
 
-    ``draft.create`` is kept forever too: it is a registered action, so it can
-    stand as a survivor that the OpenSearch rebuild reindexes from PostgreSQL,
-    which an unregistered action could not.
+    ``draft.create`` is kept forever too. It is a registered action, so it can be a
+    kept row that the OpenSearch rebuild reindexes from PostgreSQL; an unregistered
+    action could not.
     """
     set_app_config_fn_scoped(
         {
@@ -98,61 +96,37 @@ def retention_config(set_app_config_fn_scoped):
 
 
 @pytest.fixture()
-def partitioned_table(app, db, retention_config):
-    """Convert ``audit_logs_metadata`` to a monthly-partitioned table.
+def partitioned_table(app, db, retention_config, partition_audit_table):
+    """Partition ``audit_logs_metadata`` by ``created``, one child per month.
 
-    Mirrors what an operator would set up with tooling such as ``pg_partman``:
-    drop the plain table and recreate it ranged by ``created``, with one child per
-    month from two years back through next month. The current and next months
-    cover live ingestion; the older children are the cold partitions retention
-    operates on. PostgreSQL requires the range key in the primary key, so the key
-    becomes ``(id, created)``; the SQLAlchemy model keeps its single-column id key
-    and never sees this.
+    Like what an operator would set up with a tool such as ``pg_partman``: one child
+    per month from two years back to next month. The current and next months take
+    new rows; the older ones are what retention works on. ``partition_audit_table``
+    builds the table from the model, so only the monthly ranges are here. PostgreSQL
+    needs the partition key in the primary key, so it becomes ``(id, created)``; the
+    model keeps its single id key and never sees this.
     """
-    if db.engine.name != "postgresql":
-        pytest.skip("Partitioning only runs on PostgreSQL")
-
     with app.app_context():
         now = datetime.now(UTC).replace(tzinfo=None)
         month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
 
-        db.session.execute(text("DROP TABLE audit_logs_metadata"))
-        db.session.execute(
-            text(
-                """
-                CREATE TABLE audit_logs_metadata (
-                    id UUID NOT NULL,
-                    created TIMESTAMP WITHOUT TIME ZONE NOT NULL,
-                    updated TIMESTAMP WITHOUT TIME ZONE NOT NULL,
-                    action VARCHAR(255) NOT NULL,
-                    resource_type VARCHAR(255) NOT NULL,
-                    user_id VARCHAR(255) NOT NULL,
-                    json JSONB,
-                    version_id INTEGER NOT NULL,
-                    PRIMARY KEY (id, created)
-                ) PARTITION BY RANGE (created)
-                """
-            )
-        )
+        children = {}
         for n in range(24, -2, -1):
             start = _months_before(month_start, n)
             end = _next_month(start)
             name = f"audit_logs_metadata_y{start.year}_m{start.month:02d}"
-            db.session.execute(
-                text(
-                    f"CREATE TABLE {name} PARTITION OF audit_logs_metadata "
-                    f"FOR VALUES FROM ('{start:%Y-%m-%d}') TO ('{end:%Y-%m-%d}')"
-                )
-            )
-        db.session.commit()
+            children[name] = (f"{start:%Y-%m-%d}", f"{end:%Y-%m-%d}")
+        partition_audit_table(
+            "RANGE (created)", children, primary_key=("id", "created")
+        )
         yield month_start
 
 
 def test_fully_expired_partition_is_emptied(app, partitioned_table):
-    """A cold month whose every row is expired is cleared down to nothing."""
+    """An old month where every row has expired is emptied."""
     with app.app_context():
         month_start = partitioned_table
-        # 20 months old, only default-retention actions: the whole month expires.
+        # 20 months old with only default-retention actions, so the whole month goes.
         expired_month = _months_before(month_start, 20)
         a = _insert("record.publish", expired_month)
         b = _insert("record.publish", expired_month + timedelta(days=3))
@@ -167,7 +141,7 @@ def test_fully_expired_partition_is_emptied(app, partitioned_table):
 
         assert deleted == {"record.publish": 2}
         assert _remaining_ids() == set()
-        # The partition is truncated, not dropped: it survives for future writes.
+        # The partition is emptied, not dropped, so it can still take new rows.
         assert partition in _partition_names()
         after = db.session.execute(text(f"SELECT count(*) FROM {partition}")).scalar()
         assert after == 0
@@ -175,21 +149,21 @@ def test_fully_expired_partition_is_emptied(app, partitioned_table):
 
 
 def test_partition_with_survivors_is_rewritten(app, partitioned_table):
-    """A cold month keeps its survivors and loses only its expired rows."""
+    """An old month keeps the rows that have not expired and drops the rest."""
     with app.app_context():
         month_start = partitioned_table
-        # Five months back: the login (two-month period) expires, the kept-forever
-        # creation survives, so the cold child must be rewritten down to it.
-        cold_month = _months_before(month_start, 5)
-        expired_login = _insert("user.login", cold_month)
-        kept = _insert("draft.create", cold_month + timedelta(days=2))
+        # Five months back: the login (kept 2 months) expires; the kept-forever
+        # create stays, so the partition is rewritten down to it.
+        old_month = _months_before(month_start, 5)
+        expired_login = _insert("user.login", old_month)
+        kept = _insert("draft.create", old_month + timedelta(days=2))
 
-        partition = f"audit_logs_metadata_y{cold_month.year}_m{cold_month.month:02d}"
+        partition = f"audit_logs_metadata_y{old_month.year}_m{old_month.month:02d}"
 
         deleted = delete_expired_audit_logs()
 
         assert deleted == {"user.login": 1}
-        # The survivor stays, with its original id, in the same partition.
+        # The kept row stays, with its original id, in the same partition.
         assert _remaining_ids() == {kept}
         assert expired_login not in _remaining_ids()
         held = db.session.execute(text(f"SELECT id::text FROM {partition}")).fetchall()
@@ -197,7 +171,7 @@ def test_partition_with_survivors_is_rewritten(app, partitioned_table):
 
 
 def test_current_partition_is_untouched(app, partitioned_table):
-    """The hot current month is never read or rewritten by the task."""
+    """The current month is never read or rewritten by the task."""
     with app.app_context():
         month_start = partitioned_table
         now = datetime.now(UTC).replace(tzinfo=None)
@@ -222,11 +196,11 @@ def test_current_partition_is_untouched(app, partitioned_table):
 
 
 def test_partitioned_matches_default_outcome(app, partitioned_table):
-    """The partitioned profile leaves the same survivors as the batched path.
+    """The partitioned table ends with the same rows as the batched delete.
 
-    The seed and expected survivors match ``test_deletes_only_expired`` in
-    ``test_retention.py``, which runs the batched DELETE on a plain table. Equal
-    survivors and an equal report show the two profiles share retention semantics.
+    The setup and expected kept rows match ``test_deletes_only_expired`` in
+    ``test_retention.py``, which runs the batched delete on a plain table. Same rows
+    kept and same report means both ways behave the same.
     """
     with app.app_context():
         month_start = partitioned_table
@@ -250,23 +224,23 @@ def test_partitioned_matches_default_outcome(app, partitioned_table):
 
 
 def test_partitioned_run_is_idempotent(app, partitioned_table):
-    """A second partitioned run drops nothing and keeps the survivors."""
+    """Running it again deletes nothing and keeps the same rows."""
     with app.app_context():
         month_start = partitioned_table
         _insert("user.login", _months_before(month_start, 5))
         _insert("user.block", _months_before(month_start, 10))
 
         delete_expired_audit_logs()
-        survivors = _remaining_ids()
+        kept = _remaining_ids()
 
         deleted = delete_expired_audit_logs()
 
         assert deleted == {}
-        assert _remaining_ids() == survivors
+        assert _remaining_ids() == kept
 
 
 def test_partitioned_run_log_records_each_month(app, partitioned_table):
-    """One run-log entry per deleted month, matching the batched profile."""
+    """One run-log entry per deleted month, same as the batched version."""
     with app.app_context():
         month_start = partitioned_table
         _insert("user.login", _months_before(month_start, 4))

--- a/tests/services/test_retention_partitioned.py
+++ b/tests/services/test_retention_partitioned.py
@@ -1,0 +1,319 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Retention against a monthly-partitioned ``audit_logs_metadata``.
+
+The default profile deletes scattered rows in batches; the scale profile lets an
+operator partition the table by month and the task then drops or rewrites whole
+cold partitions instead. Both profiles must reach the same end state, so these
+tests seed an operator-style partitioned table and assert the same survivors the
+batched path produces, plus that the rewrite touches only cold children.
+
+The fixture partitions on ``created`` rather than the UUIDv7 id used by the
+prior-art ``test_partitioned_compatibility.py``. Until the id migration lands the
+model still issues uuid4 ids, which would fall outside any id-based partition
+range; partitioning on ``created`` matches how retention keys its cutoffs and
+keeps the task's partition handling agnostic to the partition key. The setup runs
+inside the test's own transaction, so the savepoint-based ``db`` fixture rolls the
+table back to a plain table after each test with no leakage.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from invenio_access.permissions import system_identity
+from invenio_db import db
+from sqlalchemy import text
+
+from invenio_audit_logs import KEEP_FOREVER
+from invenio_audit_logs.records.models import AuditLog, RetentionRun
+from invenio_audit_logs.tasks import delete_expired_audit_logs
+
+UTC = timezone.utc
+
+
+def _months_before(month_start, n):
+    """Return the start of the month ``n`` months before ``month_start``."""
+    total = month_start.year * 12 + (month_start.month - 1) - n
+    year, month = divmod(total, 12)
+    return month_start.replace(year=year, month=month + 1)
+
+
+def _next_month(month_start):
+    """Return the first instant of the month after ``month_start``."""
+    if month_start.month == 12:
+        return month_start.replace(year=month_start.year + 1, month=1)
+    return month_start.replace(month=month_start.month + 1)
+
+
+def _insert(action, created):
+    """Insert an audit log row with a chosen ``created`` timestamp."""
+    row = AuditLog(
+        action=action,
+        resource_type="record",
+        user_id="1",
+        json={},
+        created=created,
+        updated=created,
+    )
+    db.session.add(row)
+    db.session.commit()
+    return row.id
+
+
+def _remaining_ids():
+    """Return the set of ids currently in the table."""
+    return {row[0] for row in db.session.query(AuditLog.id).all()}
+
+
+def _partition_names():
+    """Return the monthly child partitions, ordered by name."""
+    rows = db.session.execute(
+        text(
+            "SELECT tablename FROM pg_tables "
+            "WHERE tablename LIKE 'audit_logs_metadata_y%' ORDER BY tablename"
+        )
+    ).fetchall()
+    return [row[0] for row in rows]
+
+
+@pytest.fixture()
+def retention_config(set_app_config_fn_scoped):
+    """Two-month logins, kept-forever blocks, 13-month default.
+
+    ``draft.create`` is kept forever too: it is a registered action, so it can
+    stand as a survivor that the OpenSearch rebuild reindexes from PostgreSQL,
+    which an unregistered action could not.
+    """
+    set_app_config_fn_scoped(
+        {
+            "AUDIT_LOGS_RETENTION": {
+                "user.login": timedelta(days=60),
+                "user.block": KEEP_FOREVER,
+                "draft.create": KEEP_FOREVER,
+            },
+            "AUDIT_LOGS_RETENTION_DEFAULT": timedelta(days=395),
+        }
+    )
+
+
+@pytest.fixture()
+def partitioned_table(app, db, retention_config):
+    """Convert ``audit_logs_metadata`` to a monthly-partitioned table.
+
+    Mirrors what an operator would set up with tooling such as ``pg_partman``:
+    drop the plain table and recreate it ranged by ``created``, with one child per
+    month from two years back through next month. The current and next months
+    cover live ingestion; the older children are the cold partitions retention
+    operates on. PostgreSQL requires the range key in the primary key, so the key
+    becomes ``(id, created)``; the SQLAlchemy model keeps its single-column id key
+    and never sees this.
+    """
+    if db.engine.name != "postgresql":
+        pytest.skip("Partitioning only runs on PostgreSQL")
+
+    with app.app_context():
+        now = datetime.now(UTC).replace(tzinfo=None)
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+        db.session.execute(text("DROP TABLE audit_logs_metadata"))
+        db.session.execute(
+            text(
+                """
+                CREATE TABLE audit_logs_metadata (
+                    id UUID NOT NULL,
+                    created TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+                    updated TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+                    action VARCHAR(255) NOT NULL,
+                    resource_type VARCHAR(255) NOT NULL,
+                    user_id VARCHAR(255) NOT NULL,
+                    json JSONB,
+                    version_id INTEGER NOT NULL,
+                    PRIMARY KEY (id, created)
+                ) PARTITION BY RANGE (created)
+                """
+            )
+        )
+        for n in range(24, -2, -1):
+            start = _months_before(month_start, n)
+            end = _next_month(start)
+            name = f"audit_logs_metadata_y{start.year}_m{start.month:02d}"
+            db.session.execute(
+                text(
+                    f"CREATE TABLE {name} PARTITION OF audit_logs_metadata "
+                    f"FOR VALUES FROM ('{start:%Y-%m-%d}') TO ('{end:%Y-%m-%d}')"
+                )
+            )
+        db.session.commit()
+        yield month_start
+
+
+def test_fully_expired_partition_is_emptied(app, partitioned_table):
+    """A cold month whose every row is expired is cleared down to nothing."""
+    with app.app_context():
+        month_start = partitioned_table
+        # 20 months old, only default-retention actions: the whole month expires.
+        expired_month = _months_before(month_start, 20)
+        a = _insert("record.publish", expired_month)
+        b = _insert("record.publish", expired_month + timedelta(days=3))
+
+        partition = (
+            f"audit_logs_metadata_y{expired_month.year}_m{expired_month.month:02d}"
+        )
+        before = db.session.execute(text(f"SELECT count(*) FROM {partition}")).scalar()
+        assert before == 2
+
+        deleted = delete_expired_audit_logs()
+
+        assert deleted == {"record.publish": 2}
+        assert _remaining_ids() == set()
+        # The partition is truncated, not dropped: it survives for future writes.
+        assert partition in _partition_names()
+        after = db.session.execute(text(f"SELECT count(*) FROM {partition}")).scalar()
+        assert after == 0
+        assert {a, b}.isdisjoint(_remaining_ids())
+
+
+def test_partition_with_survivors_is_rewritten(app, partitioned_table):
+    """A cold month keeps its survivors and loses only its expired rows."""
+    with app.app_context():
+        month_start = partitioned_table
+        # Five months back: the login (two-month period) expires, the kept-forever
+        # creation survives, so the cold child must be rewritten down to it.
+        cold_month = _months_before(month_start, 5)
+        expired_login = _insert("user.login", cold_month)
+        kept = _insert("draft.create", cold_month + timedelta(days=2))
+
+        partition = f"audit_logs_metadata_y{cold_month.year}_m{cold_month.month:02d}"
+
+        deleted = delete_expired_audit_logs()
+
+        assert deleted == {"user.login": 1}
+        # The survivor stays, with its original id, in the same partition.
+        assert _remaining_ids() == {kept}
+        assert expired_login not in _remaining_ids()
+        held = db.session.execute(text(f"SELECT id::text FROM {partition}")).fetchall()
+        assert [row[0] for row in held] == [str(kept)]
+
+
+def test_current_partition_is_untouched(app, partitioned_table):
+    """The hot current month is never read or rewritten by the task."""
+    with app.app_context():
+        month_start = partitioned_table
+        now = datetime.now(UTC).replace(tzinfo=None)
+        # A recent login (within its period) and an old login that must expire.
+        recent = _insert("user.login", now)
+        old = _insert("user.login", _months_before(month_start, 5))
+
+        current_partition = (
+            f"audit_logs_metadata_y{month_start.year}_m{month_start.month:02d}"
+        )
+
+        deleted = delete_expired_audit_logs()
+
+        assert deleted == {"user.login": 1}
+        assert _remaining_ids() == {recent}
+        assert old not in _remaining_ids()
+        # The current partition still holds exactly the recent row, untouched.
+        held = db.session.execute(
+            text(f"SELECT id::text FROM {current_partition}")
+        ).fetchall()
+        assert [row[0] for row in held] == [str(recent)]
+
+
+def test_partitioned_matches_default_outcome(app, partitioned_table):
+    """The partitioned profile leaves the same survivors as the batched path.
+
+    The seed and expected survivors match ``test_deletes_only_expired`` in
+    ``test_retention.py``, which runs the batched DELETE on a plain table. Equal
+    survivors and an equal report show the two profiles share retention semantics.
+    """
+    with app.app_context():
+        month_start = partitioned_table
+        now = datetime.now(UTC).replace(tzinfo=None)
+        ids = {
+            "old_login": _insert("user.login", _months_before(month_start, 5)),
+            "recent_login": _insert("user.login", now),
+            "old_block": _insert("user.block", _months_before(month_start, 10)),
+            "publish_recent": _insert("record.publish", _months_before(month_start, 5)),
+            "publish_old": _insert("record.publish", _months_before(month_start, 20)),
+        }
+
+        deleted = delete_expired_audit_logs()
+
+        assert deleted == {"user.login": 1, "record.publish": 1}
+        assert _remaining_ids() == {
+            ids["recent_login"],
+            ids["old_block"],
+            ids["publish_recent"],
+        }
+
+
+def test_partitioned_run_is_idempotent(app, partitioned_table):
+    """A second partitioned run drops nothing and keeps the survivors."""
+    with app.app_context():
+        month_start = partitioned_table
+        _insert("user.login", _months_before(month_start, 5))
+        _insert("user.block", _months_before(month_start, 10))
+
+        delete_expired_audit_logs()
+        survivors = _remaining_ids()
+
+        deleted = delete_expired_audit_logs()
+
+        assert deleted == {}
+        assert _remaining_ids() == survivors
+
+
+def test_partitioned_run_log_records_each_month(app, partitioned_table):
+    """One run-log entry per deleted month, matching the batched profile."""
+    with app.app_context():
+        month_start = partitioned_table
+        _insert("user.login", _months_before(month_start, 4))
+        _insert("user.login", _months_before(month_start, 4) + timedelta(days=1))
+        _insert("user.login", _months_before(month_start, 6))
+
+        delete_expired_audit_logs()
+
+        logins = (
+            db.session.query(RetentionRun)
+            .filter(RetentionRun.action == "user.login")
+            .all()
+        )
+        assert {(run.month, run.rows_deleted) for run in logins} == {
+            (_months_before(month_start, 4).date(), 2),
+            (_months_before(month_start, 6).date(), 1),
+        }
+
+
+def test_partitioned_dry_run_changes_nothing(app, partitioned_table):
+    """A dry run reports the expired rows but writes nothing to either store."""
+    with app.app_context():
+        month_start = partitioned_table
+        expired_month = _months_before(month_start, 20)
+        _insert("record.publish", expired_month)
+        before = _remaining_ids()
+
+        report = delete_expired_audit_logs(dry_run=True)
+
+        assert report == {"record.publish": {expired_month.date(): 1}}
+        assert _remaining_ids() == before
+        assert db.session.query(RetentionRun).count() == 0
+
+
+def test_model_and_service_unaware_of_partitioning(
+    app, service, resource_data, partitioned_table
+):
+    """The model stays single-table and the service reads and writes normally."""
+    with app.app_context():
+        # The model still maps to one plain table with a single-column id key.
+        assert AuditLog.__tablename__ == "audit_logs_metadata"
+        assert AuditLog.__table__.primary_key.columns.keys() == ["id"]
+
+        resource_data["resource"]["id"] = "partitioned-transparency"
+        with app.test_request_context():
+            created = service.create(identity=system_identity, data=resource_data)
+            fetched = service.read(identity=system_identity, id_=created.id)
+
+        assert fetched["resource"]["id"] == "partitioned-transparency"
+        assert fetched["action"] == "draft.create"

--- a/tests/services/test_service.py
+++ b/tests/services/test_service.py
@@ -3,7 +3,6 @@
 """Test audit log service."""
 
 import pytest
-from flask import g
 from flask_login import login_user
 from invenio_access.permissions import system_identity
 from invenio_records_resources.services.errors import PermissionDeniedError
@@ -55,7 +54,7 @@ def test_audit_log_create(
     expected_links = {
         "self": (
             "https://127.0.0.1:5000/api/audit-logs/?"
-            f"page=1&q=resource.id:+abcd-1234+AND+action:+draft.create"
+            "page=1&q=resource.id:+abcd-1234+AND+action:+draft.create"
             "&size=20&sort=newest"
         )
     }

--- a/tests/services/test_uuidv7_migration.py
+++ b/tests/services/test_uuidv7_migration.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the migration that changes existing ids to UUIDv7.
+
+The migration rebuilds each id from the row's ``created`` time so the table can be
+partitioned by time. These tests run the migration's own SQL on some seeded rows
+and check that the ids become UUIDv7 in time order, that the count and uniqueness
+hold, that retention still deletes by ``created`` (not by id), and that the search
+copy can be rebuilt with the new ids.
+"""
+
+import importlib.util
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from invenio_access.permissions import system_identity
+from invenio_db import db
+from invenio_search import current_search_client
+from sqlalchemy import text
+
+import invenio_audit_logs
+from invenio_audit_logs.records.models import AuditLog
+from invenio_audit_logs.tasks import delete_expired_audit_logs
+
+UTC = timezone.utc
+
+
+def _migration_sql():
+    """Read the rewrite SQL from the migration file so the test runs the real thing.
+
+    The ``alembic`` folder is not a Python package, so the file is loaded by path
+    instead of imported.
+    """
+    path = (
+        Path(invenio_audit_logs.__file__).parent
+        / "alembic"
+        / "f0e1d2c3b4a5_rewrite_ids_to_uuid7.py"
+    )
+    spec = importlib.util.spec_from_file_location("_rewrite_ids_to_uuid7", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.REWRITE_IDS_TO_UUID7
+
+
+REWRITE_SQL = _migration_sql()
+
+
+def _ts_ms(value):
+    """Get the millisecond timestamp back out of a UUIDv7."""
+    return (value.int >> 80) & ((1 << 48) - 1)
+
+
+def _insert(id_, action, created):
+    """Insert an audit log row with a chosen id and ``created`` timestamp."""
+    row = AuditLog(
+        id=id_,
+        action=action,
+        resource_type="record",
+        user_id="1",
+        json={},
+        created=created,
+        updated=created,
+    )
+    db.session.add(row)
+    db.session.commit()
+    return id_
+
+
+def _rewrite():
+    """Run the migration's rewrite SQL and refresh the session's view of the rows."""
+    db.session.execute(text(REWRITE_SQL))
+    db.session.expire_all()
+
+
+@pytest.fixture(autouse=True)
+def _clean_audit_search(app):
+    """Delete the monthly ``auditlog`` indices a test fills so they don't reach the next."""
+    yield
+    with app.app_context():
+        current_search_client.indices.delete(index="auditlog*", ignore_unavailable=True)
+
+
+def test_rewrite_replaces_uuid4_with_uuid7_derived_from_created(app, db):
+    """Every id becomes a unique UUIDv7 based on its ``created`` time."""
+    if db.engine.name != "postgresql":
+        pytest.skip("Id rewrite runs against PostgreSQL")
+
+    with app.app_context():
+        seeds = {
+            uuid4(): ("user.login", datetime(2024, 3, 10, 8, 30)),
+            uuid4(): ("record.publish", datetime(2025, 7, 2, 9, 0)),
+            uuid4(): ("user.login", datetime(2025, 7, 2, 9, 0)),
+        }
+        for old_id, (action, created) in seeds.items():
+            _insert(old_id, action, created)
+
+        _rewrite()
+
+        rows = db.session.query(AuditLog).all()
+        new_ids = {row.id for row in rows}
+
+        assert len(new_ids) == 3
+        assert new_ids.isdisjoint(seeds.keys())
+        for row in rows:
+            assert row.id.version == 7
+            expected = int(row.created.replace(tzinfo=UTC).timestamp() * 1000)
+            assert _ts_ms(row.id) == expected
+
+
+def test_rewrite_preserves_time_order(app, db):
+    """After the rewrite, an earlier ``created`` gives a smaller id than a later one."""
+    if db.engine.name != "postgresql":
+        pytest.skip("Id rewrite runs against PostgreSQL")
+
+    with app.app_context():
+        _insert(uuid4(), "user.login", datetime(2020, 1, 1))
+        _insert(uuid4(), "user.login", datetime(2026, 1, 1))
+
+        _rewrite()
+
+        ordered = db.session.query(AuditLog).order_by(AuditLog.created).all()
+        assert ordered[0].id < ordered[1].id
+
+
+def test_retention_still_keys_on_created_after_rewrite(
+    app, db, set_app_config_fn_scoped
+):
+    """Rewriting ids does not change which rows retention expires."""
+    if db.engine.name != "postgresql":
+        pytest.skip("Retention runs against PostgreSQL")
+
+    set_app_config_fn_scoped(
+        {
+            "AUDIT_LOGS_RETENTION": {"user.login": timedelta(days=60)},
+            "AUDIT_LOGS_RETENTION_DEFAULT": timedelta(days=395),
+        }
+    )
+
+    with app.app_context():
+        now = datetime.now(UTC).replace(tzinfo=None)
+        _insert(uuid4(), "user.login", now)
+        _insert(uuid4(), "user.login", now - timedelta(days=200))
+
+        _rewrite()
+
+        deleted = delete_expired_audit_logs()
+
+        survivors = db.session.query(AuditLog).all()
+        assert deleted == {"user.login": 1}
+        assert len(survivors) == 1
+        assert survivors[0].created.date() == now.date()
+
+
+def test_reindex_after_rewrite_is_searchable(app, db, service):
+    """The search copy can be rebuilt from PostgreSQL with the new ids."""
+    if db.engine.name != "postgresql":
+        pytest.skip("Reindex runs against PostgreSQL and OpenSearch")
+
+    with app.app_context():
+        _insert(uuid4(), "draft.create", datetime.now(UTC).replace(tzinfo=None))
+
+        _rewrite()
+        new_id = db.session.query(AuditLog.id).scalar()
+
+        reindexed = service.reindex(system_identity)
+        service.record_cls.index.refresh()
+        with app.test_request_context():
+            results = service.search(
+                identity=system_identity, params={"q": "action: draft.create"}
+            )
+
+        assert new_id.version == 7
+        assert reindexed == 1
+        assert results.total == 1


### PR DESCRIPTION
> AI disclaimer: pretty much the entire feature was written with Claude Code, based on a discussion on how I imagined implementing this and going through the various caveats.

- **feat(retention): add config, resolver, and monthly DB deletion**
  * Add `AUDIT_LOGS_RETENTION`, `AUDIT_LOGS_RETENTION_DEFAULT`, and the `KEEP_FOREVER` sentinel; the default stays finite (395 days) so an unconfigured action is kept for a bounded period rather than forever by oversight.
  * Add `RetentionPolicy`, an I/O-free resolver mapping an action to its whole-month expiry cutoff, or reporting that the action is kept forever.
  * Add the `delete_expired_audit_logs` Celery task: it deletes PostgreSQL rows older than each action's cutoff in bounded batches, keys on `created` to stay independent of the id version, and guards against overlapping runs with a single-run lock.
  

- **feat(retention): record deleted months in a run log**
  * Add a RetentionRun model and audit_logs_retention_runs table, kept
    apart from audit_logs_metadata so the proof survives the deletions it
    records, since the audit log is itself subject to retention.
  * Have the deletion task write one entry per deleted (action, month) with the
    rows-deleted count, applied retention period, and status; the table
    carries no event content.
  * Add the Alembic migration that creates the table.
  

- **feat(retention): add dry-run mode to retention task**
  * a dry_run flag counts the rows each action would delete per month and reports them without deleting from PostgreSQL or writing a run log entry, so an operator can validate a policy change before enforcing it.
  * the preview reads the same months an enforced run deletes, so its counts match what the next real run removes.
  

- **feat(retention): move search copy to monthly indices**
  * Replace the managed data stream with a plain auditlog* index template
    carrying the mappings and the auditlog read alias.
  * Route each event to auditlog-YYYY-MM derived from its created timestamp,
    so the template auto-creates and aliases the index on first write, with
    no write alias and no rollover job.
  * Add a reindex method that replays PostgreSQL rows into the monthly
    layout; PostgreSQL is authoritative, so the move off the stream rebuilds
    the search copy rather than copying it.
  

- **feat(retention): delete from OpenSearch before PostgreSQL**
  * Drop or rebuild each monthly index from PostgreSQL: a month with no
    survivors loses its whole index, while a month that keeps survivors is
    reindexed into a fresh index. Expired documents go with their index, so
    no delete_by_query is issued.
  * Delete from OpenSearch before the PostgreSQL delete. A crash between the two
    then leaves search showing fewer events than the authoritative store,
    never more, and a later run reconciles the drift from PostgreSQL.
  

- **feat(retention): partition-aware PostgreSQL deletion**
  * On a monthly-partitioned table the task operates on cold child partitions
    instead of batched DELETEs: a fully expired child is truncated, and a child
    that still holds survivors is rewritten by copying survivors to a temp table,
    truncating, and reinserting, so only survivors reach the write-ahead log and
    the ACCESS EXCLUSIVE lock stays scoped to that cold child.
  * The current (hot) month is never touched, because month-aligned cutoffs leave
    no expired rows there.
  * Partition detection reads the catalog relkind; the child for a month is found
    from a row's tableoid, keeping the task agnostic to whether partitions range
    on created or on a UUIDv7 id. The model and service API stay single-table and
    unaware of partitioning.
  * Both profiles share retention semantics and produce the same run log and
    report; only the PostgreSQL deletion mechanism differs.
  

- **feat(models): use UUIDv7 for `AuditLog.id`**
  

- **feat(retention): migrate existing ids to UUIDv7 derived from created**
  * Add a migration that gives every existing row a UUIDv7 id built from its
    `created` time, in one PostgreSQL UPDATE: a 48-bit millisecond timestamp, the
    digit 7, then random bits from `gen_random_uuid()`. This lets an operator
    partition the table by time on the primary key.
  * Changing the id is safe: audit log ids are never foreign keys, and retention
    deletes by `created`, not by id, so nothing else changes. Rebuild the search copy
    from PostgreSQL with `AuditLogService.reindex` afterwards. The downgrade does
    nothing, since the old ids are gone and nothing points at them.
  

- **test(retention): add partitioned-table tests built from the model**
  * Partition `audit_logs_metadata` by ranges of its UUIDv7 id and check that
    create, read, search, and the model still work, since the module should not need
    to know the table is partitioned.
  * Add a `partition_audit_table` fixture that builds the partitioned table from the
    model own columns, and use it for both the compatibility test (partitioned by id)
    and the retention test (partitioned by created), so the test tables stay in sync
    with the model. The retention test previously hand-wrote the columns, even using
    TIMESTAMP WITHOUT TIME ZONE where the model uses WITH TIME ZONE.
  